### PR TITLE
Replaced LogCategoryType.LibraryType with default CustomLogCategory

### DIFF
--- a/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigureWithOptionsTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigureWithOptionsTests.cs
@@ -10,7 +10,7 @@
         {
             var actual = new ConfigureWithOptions();
 
-            actual.CustomLogCategory.Should().BeEmpty();
+            actual.CustomLogCategory.Should().Be("Neovolve.Configuration.DependencyInjection.ConfigureWith");
             actual.LogCategoryType.Should().Be(LogCategoryType.TargetType);
             actual.LogReadOnlyPropertyType.Should().Be(LogReadOnlyPropertyType.ValueTypesOnly);
             actual.LogReadOnlyPropertyLevel.Should().Be(LogLevel.Warning);

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/TypeRegistrationExtensionsTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/TypeRegistrationExtensionsTests.cs
@@ -83,8 +83,7 @@
 
         [Theory]
         [InlineData(LogCategoryType.TargetType, "Neovolve.Configuration.DependencyInjection.UnitTests.FirstConfig")]
-        [InlineData(LogCategoryType.LibraryType, "Neovolve.Configuration.DependencyInjection.ConfigureWith")]
-        [InlineData(LogCategoryType.Custom, "A436F5013F574906BAE263824DEFA140")]
+        [InlineData(LogCategoryType.Custom, "Neovolve.Configuration.DependencyInjection.ConfigureWith")]
         public void ConfigureWithLogsConfigurationUpdatesBasedOnLogCategoryOptions(LogCategoryType logCategoryType,
             string expectedCategory)
         {

--- a/Neovolve.Configuration.DependencyInjection/ConfigureWithOptions.cs
+++ b/Neovolve.Configuration.DependencyInjection/ConfigureWithOptions.cs
@@ -9,7 +9,7 @@
     public class ConfigureWithOptions : IConfigureWithOptions
     {
         /// <inheritdoc />
-        public string CustomLogCategory { get; set; } = string.Empty;
+        public string CustomLogCategory { get; set; } = "Neovolve.Configuration.DependencyInjection.ConfigureWith";
 
         /// <inheritdoc />
         public LogCategoryType LogCategoryType { get; set; } = LogCategoryType.TargetType;

--- a/Neovolve.Configuration.DependencyInjection/LogCategoryType.cs
+++ b/Neovolve.Configuration.DependencyInjection/LogCategoryType.cs
@@ -13,11 +13,6 @@ public enum LogCategoryType
     TargetType,
 
     /// <summary>
-    /// Log messages are written to a category of this library.
-    /// </summary>
-    LibraryType,
-
-    /// <summary>
     /// Log messages are written to a category defined by <see cref="ConfigureWithOptions.CustomLogCategory"/>.
     /// </summary>
     Custom

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The following are the default options that `ConfigureWith<T>` uses.
 | Option | Type | Default | Description |
 |-|-|-|-|
 | CustomLogCategory | `string` | `string.Empty` | The custom log category used when `LogCategoryType` is `LogCategoryType.Custom` |
-| LogCategoryType | `LogCategoryType` | `LogCategoryType.TargetType` | The log category to use when logging messages for configuration updates on raw types. Supported values are `TargetType`, `LibraryType` and `Custom`. |
+| LogCategoryType | `LogCategoryType` | `LogCategoryType.TargetType` | The log category to use when logging messages for configuration updates on raw types. Supported values are `TargetType` or `Custom`. |
 | LogReadOnlyPropertyLevel | `LogLevel` | `LogLevel.Warning` in Development; otherwise `Debug` | The log level to use when logging that updates are detected for read-only properties |
 | LogReadOnlyPropertyType | `LogReadOnlyPropertyType` | `LogReadOnlyPropertyType.ValueTypesOnly` | The types of read-only properties to log when they are updated. Supported values are `All`, `ValueTypesOnly` and `None.` |
 | ReloadInjectedRawTypes | `bool` | `true` | Determines if raw types that are injected into the configuration system should be reloaded when the configuration changes |


### PR DESCRIPTION
Replaced LogCategoryType.LibraryType with default on ConfigureWithOptions.CustomLogCategory