### PR TITLE
Modernize build, test and CI infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,67 +15,90 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # pull-requests: write lets the coverage step post and update a PR comment via the gh CLI on
+    # same-repo PRs. contents: read covers checkout and the GitVersion history fetch.
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.10.2
+      uses: gittools/actions/gitversion/setup@v4
       with:
-          versionSpec: '5.x'
+          versionSpec: '6.x'
     
     - name: Use GitVersion
-      id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v0.10.2
+      id: gitversion # step id used as reference for output values (consumed by the version.txt step)
+      uses: gittools/actions/gitversion/execute@v4
       with:
-        useConfigFile: true
         configFilePath: ./GitVersion.yml
 
-    - name: Update project version
-      uses: roryprimrose/set-vs-sdk-project-version@v1.0.6
+    # Assembly and package version stamping is handled by GitVersion.MsBuild during the build (referenced
+    # CI-only from Directory.Build.props), replacing the deprecated set-vs-sdk-project-version action that
+    # mutated the csproj files. The GitVersion CLI step above remains the source for version.txt, which the
+    # release job uses for the tag, release name and asset filenames; both read the same GitVersion.yml so
+    # the value always matches the packaged version.
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v5
       with:
-        version: ${{ steps.gitversion.outputs.NuGetVersionV2 }}
-        assemblyVersion: ${{ steps.gitversion.outputs.AssemblySemVer }}
-        fileVersion: ${{ steps.gitversion.outputs.MajorMinorPatch }}
-        informationalVersion: ${{ steps.gitversion.outputs.InformationalVersion }}  
-        
-    - name: Setup dotnet v8.0
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '8.x' # SDK Version to use.
+        # 10.x provides the SDK pinned in global.json; 8.x and 9.x provide the runtimes the
+        # multi-targeted tests run on (net8.0;net9.0;net10.0).
+        dotnet-version: |
+          8.x
+          9.x
+          10.x
 
     - name: Restore
       run: dotnet restore
 
     - name: Build
       run: dotnet build -c Release --no-restore
-    
+
+    - name: Install coverage tool
+      run: dotnet tool install --global dotnet-coverage --version 18.8.0
+
     - name: Test
-      run: dotnet test -c Release --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+      # dotnet-coverage wraps the test run and instruments the test host processes, writing one merged
+      # Cobertura report. This is decoupled from the Microsoft.Testing.Platform version that xUnit v3
+      # ships, unlike the Microsoft.Testing.Extensions.CodeCoverage package which must match it exactly.
+      run: dotnet-coverage collect -f cobertura -o coverage.cobertura.xml -- dotnet test -c Release --no-build
 
+    # Coverage is collected by dotnet-coverage above (MTP-native coverlet does not run under the
+    # Microsoft Testing Platform that xUnit v3 uses). The report and comment stay entirely within
+    # GitHub Actions: ReportGenerator runs on the runner and the comment is posted with the built-in
+    # gh CLI, so no third-party service is involved.
     - name: Generate coverage report
-      # run: reportgenerator -reports:**/coverage.cobertura.xml -targetdir:Report -reporttypes:HtmlInline_AzurePipelines;Cobertura
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.2.0
+      if: ${{ !cancelled() && hashFiles('coverage.cobertura.xml') != '' }}
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10
       with:
-        reports: "**/coverage*cobertura.xml"
-        targetdir: "Report"
-        reporttypes: "HtmlInline;Cobertura"
-        tag: '${{ github.run_number }}_${{ github.run_id }}'
-      # Don't run on fork or dependabot builds
-      if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]'
+        reports: coverage.cobertura.xml
+        targetdir: coveragereport
+        reporttypes: MarkdownSummaryGithub;TextSummary
+        assemblyfilters: +Neovolve.Configuration.DependencyInjection
+        title: Code Coverage
 
-    - name: Publish coverage report
-      uses: 5monkeys/cobertura-action@master
-      with:
-        path: Report/Cobertura.xml
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        minimum_coverage: 75
-      # Don't run on fork or dependabot builds
-      if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]'
+    - name: Publish coverage to job summary
+      if: ${{ !cancelled() && hashFiles('coveragereport/SummaryGithub.md') != '' }}
+      shell: bash
+      run: cat coveragereport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Comment coverage on pull request
+      # Same-repo PRs only: a fork PR is given a read-only token that cannot post comments, so those
+      # rely on the job summary above. --edit-last --create-if-none keeps one coverage comment that is
+      # updated across the PR's commits rather than adding a new comment per build.
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && hashFiles('coveragereport/SummaryGithub.md') != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file coveragereport/SummaryGithub.md
       
     - name: Resolve project name
       shell: pwsh
@@ -85,7 +108,7 @@ jobs:
       run: dotnet pack "./${{ env.projectName }}/${{ env.projectName }}.csproj" -c Release --no-build --include-symbols -o $GITHUB_WORKSPACE/staging
 
     - name: Publish build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: packages
         path: staging
@@ -93,9 +116,9 @@ jobs:
     - shell: bash
       name: Write version
       run: |
-        echo '${{ steps.gitversion.outputs.NuGetVersionV2 }}' > version.txt
+        echo '${{ steps.gitversion.outputs.SemVer }}' > version.txt
     - name: Upload version
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: version
         path: version.txt
@@ -108,34 +131,43 @@ jobs:
 
     steps:
     - name: Download packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: packages
       
-    - name: Setup nuget
-      uses: nuget/setup-nuget@v1
-        
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.x
+
     - name: Publish to MyGet.org
       env: 
         MYGET_APIKEY: ${{ secrets.MYGET_APIKEY }}
-      run: nuget push *.*.symbols.nupkg $MYGET_APIKEY -source https://www.myget.org/F/neovolve/api/v2/package
+      run: dotnet nuget push "*.symbols.nupkg" --api-key "$MYGET_APIKEY" --source https://www.myget.org/F/neovolve/api/v2/package --skip-duplicate
       continue-on-error: true # just in case MyGet is down
       
   release:
     needs: build
     runs-on: ubuntu-latest
-    # Only run on pushes which should only be on the base repository and only where the branch is main or is a version tagged build
+    # action-gh-release needs contents: write to create the GitHub release; the GitHub Packages push
+    # below authenticates with the built-in GITHUB_TOKEN, which needs packages: write.
+    permissions:
+      contents: write
+      packages: write
+    # Run on pushes to the base repository for the default branch (main) or a version tagged build.
+    # Main builds are untagged and GitVersion stamps them as a beta pre-release (see GitVersion.yml),
+    # so they publish pre-release packages; version tags publish the stable release.
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
 
     steps:
     
     - name: Download packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: packages
       
     - name: Download version
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: version
 
@@ -143,54 +175,41 @@ jobs:
       shell: bash
       run: |
         value=`cat version.txt`
-        echo NuGetVersionV2=$(echo $value) >> $GITHUB_ENV 
+        echo SemVer=$(echo $value) >> $GITHUB_ENV 
     
     - name: Resolve project name
       shell: pwsh
       run: Add-Content -Path ${env:GITHUB_ENV} "`nprojectName=$(${env:GITHUB_REPOSITORY}.substring(${env:GITHUB_REPOSITORY}.IndexOf('/') + 1))" -Encoding utf8
       
-    - name: Setup nuget
-      uses: nuget/setup-nuget@v1
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.x
       
-      #    - name: Publish to GitHub
-#      env: 
-#        GPR_APIKEY: ${{ secrets.GPR_APIKEY }}
-#      run: nuget push *.*.symbols.nupkg $GPR_APIKEY -source https://nuget.pkg.github.com/roryprimrose/index.json
+    - name: Publish to GitHub
+      # Authenticate with the workflow's built-in GITHUB_TOKEN (scoped by packages: write above) rather
+      # than a personal access token secret, so publishing does not break when a PAT expires.
+      env: 
+        GPR_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+      run: dotnet nuget push "*.symbols.nupkg" --api-key "$GPR_APIKEY" --source https://nuget.pkg.github.com/roryprimrose/index.json --skip-duplicate
       
     - name: Publish to NuGet.org
       env: 
         NUGET_APIKEY: ${{ secrets.NUGET_APIKEY }}
-      run: nuget push *.*.symbols.nupkg $NUGET_APIKEY -source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.symbols.nupkg" --api-key "$NUGET_APIKEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
-    - name: Create release
-      id: create_release
-      uses: actions/create-release@v1.1.4
+    - name: Create release and upload assets
+      # Only create a GitHub release for an explicit version tag; main pre-release builds publish the
+      # NuGet packages above but must not create a GitHub release (and tag) on every commit.
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ env.NuGetVersionV2 }}
-        release_name: Release ${{ env.NuGetVersionV2 }}
+        tag_name: ${{ env.SemVer }}
+        name: Release ${{ env.SemVer }}
         draft: false
-        prerelease: ${{ contains(env.NuGetVersionV2, 'beta') }}
-    
-    - name: Upload release asset for package
-      id: upload-release-asset-package
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.projectName }}.${{ env.NuGetVersionV2 }}.nupkg
-        asset_name: ${{ env.projectName }}.${{ env.NuGetVersionV2 }}.nupkg
-        asset_content_type: application/zip
-    
-    - name: Upload release asset for symbol package
-      id: upload-release-asset-symbolpackage
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.projectName }}.${{ env.NuGetVersionV2 }}.symbols.nupkg
-        asset_name: ${{ env.projectName }}.${{ env.NuGetVersionV2 }}.symbols.nupkg
-        asset_content_type: application/zip
+        prerelease: ${{ contains(env.SemVer, 'beta') }}
+        files: |
+          ${{ env.projectName }}.${{ env.SemVer }}.nupkg
+          ${{ env.projectName }}.${{ env.SemVer }}.symbols.nupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,15 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
+	<!--
+		Version stamping is delegated to GitVersion.MsBuild, which computes the version from GitVersion.yml
+		during the build and sets Version/AssemblyVersion/FileVersion/InformationalVersion. It is referenced
+		only in CI (GitHub Actions sets GITHUB_ACTIONS=true); local builds skip it entirely - the package is
+		not even restored - so there is no per-build GitVersion cost on a developer machine and local builds
+		use the default 1.0.0.
+	-->
+	<ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<PackageReference Include="GitVersion.MsBuild" PrivateAssets="all" />
+	</ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,27 +6,42 @@
   </PropertyGroup>
   <ItemGroup Label="Package Versions used by this repository">
     <!-- Direct dependencies -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="ModelBuilder" Version="8.6.0" />
     <PackageVersion Include="Neovolve.Streamline.NSubstitute" Version="2.4.1" />
-    <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="xunit" Version="2.8.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.22" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageVersion Include="Neovolve.Logging.Xunit.v3" Version="7.2.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <!--
+      Test stack: xUnit v3 on Microsoft.Testing.Platform (MTP). Microsoft.NET.Test.Sdk and
+      coverlet.msbuild are intentionally absent: MTP supplies the test host (no VSTest SDK) and
+      coverage is collected in CI via the dotnet-coverage global tool, which coverlet's MSBuild
+      integration does not provide under MTP.
+    -->
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <!--
+      Microsoft.AspNetCore.Mvc.Testing is part of the ASP.NET Core shared framework, so its major
+      version must match the runtime the integration tests run on. Pin it per target framework rather
+      than to a single version (10.0.9 only supports net10.0).
+    -->
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.28" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.17" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <!-- Overrides -->
+  </ItemGroup>
+  <ItemGroup Label="Versioning. Referenced CI-only from Directory.Build.props; matches the GitVersion config.">
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.7.0" />
   </ItemGroup>
   <ItemGroup Label="Global Package References, added to every project">
     <GlobalPackageVersion Include="ReferenceTrimmer" Version="3.1.22" PrivateAssets="All" />
-    <GlobalPackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="All" />
+    <GlobalPackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,21 @@
-mode: ContinuousDeployment
+workflow: GitHubFlow/v1
+# GitVersion 6 renamed the v5 versioning modes. The v5 root 'mode: ContinuousDeployment'
+# (increment the pre-release number with the commit count so every build on a branch gets a unique
+# NuGet version) maps to v6 'mode: ContinuousDelivery'. The GitHubFlow/v1 preset defaults
+# feature/unknown branches to ManualDeployment (a fixed pre-release number), which would make
+# successive builds on the same branch collide on one package version, so they are overridden back
+# to ContinuousDelivery here. The key is 'mode'; 'deployment-mode' is silently ignored in 6.x.
 branches:
-  master:
-    tag: beta
+  main:
+    label: beta
+    mode: ContinuousDelivery
+  feature:
+    mode: ContinuousDelivery
+  unknown:
+    mode: ContinuousDelivery
   hotfix:
-    tag: useBranchName
+    regex: ^hotfix(es)?[/-]
+    source-branches:
+      - main
+    label: useBranchName
+    mode: ContinuousDelivery

--- a/Neovolve.Configuration.DependencyInjection.IntegrationTests/InjectionTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.IntegrationTests/InjectionTests.cs
@@ -6,7 +6,6 @@ using ModelBuilder;
 using Newtonsoft.Json;
 using WebTestHost;
 using Xunit;
-using Xunit.Abstractions;
 
 public sealed class InjectionTests
     : IClassFixture<CustomWebApplicationFactory<Program>>
@@ -54,9 +53,9 @@ public sealed class InjectionTests
     {
         using var client = _factory.CreateClient();
 
-        var response = await client.GetAsync(url);
+        var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         _output.WriteLine(content);
 
@@ -158,7 +157,7 @@ public sealed class InjectionTests
 
             var secondExpected = await UpdateConfig();
 
-            await Task.Delay(2000);
+            await Task.Delay(2000, TestContext.Current.CancellationToken);
 
             var secondActual = await GetData<FirstConfig>(client, url);
 
@@ -211,7 +210,7 @@ public sealed class InjectionTests
 
             var secondExpected = await UpdateConfig();
 
-            await Task.Delay(2000);
+            await Task.Delay(2000, TestContext.Current.CancellationToken);
 
             var secondActual = await GetData<SecondConfig>(client, url);
 
@@ -241,7 +240,7 @@ public sealed class InjectionTests
 
             var secondExpected = await UpdateConfig();
 
-            await Task.Delay(2000);
+            await Task.Delay(2000, TestContext.Current.CancellationToken);
 
             var secondActual = await GetData<ThirdConfig>(client, url);
 

--- a/Neovolve.Configuration.DependencyInjection.IntegrationTests/Neovolve.Configuration.DependencyInjection.IntegrationTests.csproj
+++ b/Neovolve.Configuration.DependencyInjection.IntegrationTests/Neovolve.Configuration.DependencyInjection.IntegrationTests.csproj
@@ -1,23 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
+    <!-- xUnit v3 runs on the Microsoft Testing Platform, which requires an executable test host. -->
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!--
+      The hot-reload integration tests mutate the WebTestHost appsettings.json at its (shared) content
+      root, so the per-TFM test hosts must not run concurrently or they race on that file. Run this
+      project's target frameworks sequentially; the much faster unit tests still parallelise across TFMs.
+    -->
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="ModelBuilder" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/CollectionChangeEvaluatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/CollectionChangeEvaluatorTests.cs
@@ -6,7 +6,6 @@
     using ModelBuilder;
     using Neovolve.Configuration.DependencyInjection.Comparison;
     using Neovolve.Logging.Xunit;
-    using Xunit.Abstractions;
 
     public class CollectionChangeEvaluatorTests
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/ComparableChangeEvaluatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/ComparableChangeEvaluatorTests.cs
@@ -4,7 +4,6 @@
     using Microsoft.Extensions.Logging;
     using Neovolve.Configuration.DependencyInjection.Comparison;
     using Neovolve.Logging.Xunit;
-    using Xunit.Abstractions;
 
     public class ComparableChangeEvaluatorTests
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/DictionaryChangeEvaluatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/DictionaryChangeEvaluatorTests.cs
@@ -9,7 +9,6 @@
     using Neovolve.Configuration.DependencyInjection.Comparison;
     using Neovolve.Logging.Xunit;
     using NSubstitute;
-    using Xunit.Abstractions;
 
     public class DictionaryChangeEvaluatorTests
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/EqualsChangeEvaluatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/EqualsChangeEvaluatorTests.cs
@@ -5,7 +5,6 @@
     using Microsoft.Extensions.Logging;
     using Neovolve.Configuration.DependencyInjection.Comparison;
     using Neovolve.Logging.Xunit;
-    using Xunit.Abstractions;
 
     public class EqualsChangeEvaluatorTests
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/EquatableChangeEvaluatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/Comparison/EquatableChangeEvaluatorTests.cs
@@ -6,7 +6,6 @@
     using Neovolve.Configuration.DependencyInjection.Comparison;
     using Neovolve.Configuration.DependencyInjection.UnitTests.Models;
     using Neovolve.Logging.Xunit;
-    using Xunit.Abstractions;
 
     public class EquatableChangeEvaluatorTests
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/DefaultConfigUpdaterTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/DefaultConfigUpdaterTests.cs
@@ -10,7 +10,6 @@ namespace Neovolve.Configuration.DependencyInjection.UnitTests
     using Neovolve.Logging.Xunit;
     using NSubstitute;
     using NSubstitute.ExceptionExtensions;
-    using Xunit.Abstractions;
 
     public sealed class DefaultConfigUpdaterTests : TestsInternal
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/Neovolve.Configuration.DependencyInjection.UnitTests.csproj
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/Neovolve.Configuration.DependencyInjection.UnitTests.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
+    <!-- xUnit v3 runs on the Microsoft Testing Platform, which requires an executable test host. -->
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neovolve.Logging.Xunit" />
+    <PackageReference Include="Neovolve.Logging.Xunit.v3" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="ModelBuilder" />
     <PackageReference Include="Neovolve.Streamline.NSubstitute" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/ScenarioTests/ValueProcessorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/ScenarioTests/ValueProcessorTests.cs
@@ -8,7 +8,6 @@
     using ModelBuilder;
     using Neovolve.Configuration.DependencyInjection.Comparison;
     using Neovolve.Configuration.DependencyInjection.UnitTests.Models;
-    using Xunit.Abstractions;
 
     public class ValueProcessorTests
     {

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/TypeRegistrationExtensionsTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/TypeRegistrationExtensionsTests.cs
@@ -8,7 +8,6 @@
     using Microsoft.Extensions.Options;
     using Neovolve.Configuration.DependencyInjection.UnitTests.Models;
     using NSubstitute;
-    using Xunit.Abstractions;
 
     public class TypeRegistrationExtensionsTests
     {

--- a/Neovolve.Configuration.DependencyInjection/Comparison/ComparableChangeEvaluator.cs
+++ b/Neovolve.Configuration.DependencyInjection/Comparison/ComparableChangeEvaluator.cs
@@ -10,7 +10,7 @@
                 return [];
             }
 
-            return [new(propertyPath, originalValue.ToString(), newValue.ToString())];
+            return [new(propertyPath, originalValue.ToString() ?? string.Empty, newValue.ToString() ?? string.Empty)];
         }
 
         public override int Order => int.MaxValue - 1;

--- a/Neovolve.Configuration.DependencyInjection/Comparison/DictionaryChangeEvaluator.cs
+++ b/Neovolve.Configuration.DependencyInjection/Comparison/DictionaryChangeEvaluator.cs
@@ -104,7 +104,8 @@ internal class DictionaryChangeEvaluator : InternalTypedChangeEvaluator<IDiction
                 return null;
             }
 
-            var convertedValue = (string)converter.ConvertTo(key, typeof(string));
+            // CanConvertTo(string) was verified above, so ConvertTo returns a non-null string.
+            var convertedValue = (string)converter.ConvertTo(key, typeof(string))!;
 
             convertedKeys.Add(convertedValue);
         }

--- a/Neovolve.Configuration.DependencyInjection/Comparison/EquatableChangeEvaluator.cs
+++ b/Neovolve.Configuration.DependencyInjection/Comparison/EquatableChangeEvaluator.cs
@@ -38,7 +38,8 @@
                 return [];
             }
 
-            var change = new IdentifiedChange(propertyPath, originalValue.ToString(), newValue.ToString());
+            var change = new IdentifiedChange(propertyPath, originalValue.ToString() ?? string.Empty,
+                newValue.ToString() ?? string.Empty);
 
             return [change];
         }

--- a/Neovolve.Configuration.DependencyInjection/DefaultConfigUpdater.cs
+++ b/Neovolve.Configuration.DependencyInjection/DefaultConfigUpdater.cs
@@ -85,7 +85,8 @@ public partial class DefaultConfigUpdater : IConfigUpdater
             return false;
         }
 
-        if (property.SetMethod.IsPublic == false)
+        // CanWrite being true guarantees SetMethod is not null.
+        if (property.SetMethod!.IsPublic == false)
         {
             return false;
         }

--- a/Neovolve.Configuration.DependencyInjection/Neovolve.Configuration.DependencyInjection.csproj
+++ b/Neovolve.Configuration.DependencyInjection/Neovolve.Configuration.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Neovolve.Configuration.DependencyInjection.xml</DocumentationFile>
 
 		<Title>Configuration binding dependency injection support with hot reload</Title>

--- a/Neovolve.Configuration.DependencyInjection/PropertyCache.cs
+++ b/Neovolve.Configuration.DependencyInjection/PropertyCache.cs
@@ -15,7 +15,7 @@
 
             // Either we are not auto-reloading injected types or the properties do not exist in cache yet
             var properties = (from x in targetType.GetProperties()
-                where x.CanRead && x.GetMethod.IsPublic && !x.GetIndexParameters().Any()
+                where x.CanRead && x.GetMethod!.IsPublic && !x.GetIndexParameters().Any()
                 select x).ToList();
 
             // We are only going to cache the properties of the target type if auto-reloading injected types is enabled

--- a/TestHost/TestHost.csproj
+++ b/TestHost/TestHost.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/WebTestHost/WebTestHost.csproj
+++ b/WebTestHost/WebTestHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "latestMinor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## Summary

Part 1 of the work for #72 (source generators instead of reflection). Before introducing a Roslyn generator, this brings the toolchain up to date so the generator can target modern SDKs and the test stack matches the other Neovolve repos (e.g. ModelBuilder). No public API or runtime behaviour changes.

## Changes

### Target frameworks
- Library now multi-targets `netstandard2.0;net8.0;net9.0;net10.0` (was `netstandard2.0`).
- Test and host projects target `net8.0;net9.0;net10.0`.

### Packages
- `Microsoft.Extensions.*` bumped 7.0.x → `10.0.9`; `Mvc.Testing` pinned per TFM (it tracks the ASP.NET Core shared framework); `Swashbuckle`, `NetAnalyzers`, `NSubstitute`, `FluentAssertions` (→ 8.x) updated.
- Added explicit `Newtonsoft.Json` (previously pulled in transitively).

### Test platform → xUnit v3 on Microsoft Testing Platform
- `xunit` → `xunit.v3` (3.2.2), `xunit.runner.visualstudio` → 3.1.5.
- Dropped `Microsoft.NET.Test.Sdk` and `coverlet.msbuild`.
- Added `global.json` pinning the SDK and selecting the `Microsoft.Testing.Platform` runner; test projects are now `Exe` with `UseMicrosoftTestingPlatformRunner`.
- Swapped `Neovolve.Logging.Xunit` for the xUnit v3 variant `Neovolve.Logging.Xunit.v3`; removed obsolete `Xunit.Abstractions` usings and satisfied the `xUnit1051` analyzer (`TestContext.Current.CancellationToken`).
- The hot-reload integration tests mutate a shared `appsettings.json`, so that project sets `TestTfmsInParallel=false` to run its TFMs sequentially (unit tests still parallelise).

### Versioning + CI
- Version stamping delegated to `GitVersion.MsBuild` (CI-only) via `Directory.Build.props`; `GitVersion.yml` updated to v6 modes and the `main` branch.
- CI workflow ported from ModelBuilder: `checkout@v7`, `setup-dotnet@v5` (installs 8/9/10 runtimes), `upload/download-artifact@v7/8`, GitVersion `v4`/`6.x`, coverage via `dotnet-coverage` + ReportGenerator job summary and `gh` PR comment (no third-party service), and split `build`/`publish`/`release` jobs.

### Source fixes
- Resolved nullable-annotation errors that only appear under the net8+ BCL annotations (reflection `GetMethod`/`SetMethod`, `ToString()`, `TypeConverter.ConvertTo`).

## Validation
- `dotnet build -c Release` succeeds across all TFMs.
- `dotnet test -c Release` — **1086 passed, 0 failed** (unit + integration across net8/9/10).

## Notes for review
- The release job now also publishes to GitHub Packages using the built-in `GITHUB_TOKEN` (matching ModelBuilder); the previous workflow had this commented out. Happy to drop it if you'd prefer to keep NuGet.org + MyGet only.
