### PR TITLE
Enforce data annotation validation for ConfigureWith&lt;T&gt; config types (#77)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,3 +45,8 @@ This library provides `IHostBuilder` and `IServiceCollection` extension methods 
 ## Project configuration
 
 - SDK-style projects, shared props in [Directory.Build.props](../Directory.Build.props), central package versions in [Directory.Packages.props](../Directory.Packages.props). No hardcoded secrets.
+
+## Temporary files
+
+- Any temporary files Copilot creates must live under the `.scratch` folder (gitignored), never elsewhere in the repo.
+- Place them in a per-session subfolder, e.g. `.scratch/<session>/`, and remove that folder once the files are no longer needed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Neovolve.Configuration.DependencyInjection
+
+## Project context
+
+This library provides `IHostBuilder` and `IServiceCollection` extension methods (`ConfigureWith<T>`) for registering strong typed configuration bindings as services, with nested type registration, hot reload, and validation. It ships a Roslyn source generator so binding, change application, and validation run without runtime reflection (AOT friendly). Targets `netstandard2.0;net8.0;net9.0;net10.0`; the generator and code fixes target `netstandard2.0`.
+
+## Code style
+
+- Follow [.editorconfig](../.editorconfig). 4-space indent, CRLF, UTF-8 with BOM for C#; 2 spaces for project/JSON/XML/YAML.
+- Do not use `this.`. Do not add an `Async` suffix to task-returning methods.
+- One type per file, file name matches the type.
+- Allman braces; always brace control structures. Place binary operators at the start of wrapped lines.
+- Member order: constants, static fields, instance fields, constructors, delegates, events, methods, operators, properties, indexers, nested types — public to private within each.
+- Naming: `_camelCase` for private fields, PascalCase publics, camelCase locals/parameters.
+- `using` statements only import namespaces actually used in the file; remove unused imports.
+- xmldoc must not `<see cref>`/reference a type unless the file's code already references that type (or a related type already in scope) — do not add a dependency just to document it.
+- Only add a `csproj` package reference (and central version pin) when the package is actually used; do not pin dependencies that nothing consumes.
+
+## Accessibility
+
+- Types and members are `internal` by default. Only make something `public`/`protected` if consumers call it directly or it is an extensibility point (interfaces like `IConfigUpdater`, `IConfigValidator`, options/enums, the extension classes) or generated code in consumer assemblies references it (everything in the `Generated` namespace).
+- Concrete defaults resolved through DI (`DefaultConfigUpdater`, `DefaultConfigValidator`) stay `internal`; consumers extend via the interface.
+
+## xmldoc
+
+- Required on all public packable members and on every interface, enum and struct (and their members) regardless of scope.
+- Order: summary, params, returns, exceptions, remarks, example. Use `<inheritdoc />` for inherited members; write null as `<c>null</c>`.
+
+## Async
+
+- Interface methods are task based with a `CancellationToken`. No blocking (`.Result`/`.Wait()`). Use `.ConfigureAwait(false)` in packable libraries, not in tests/examples.
+
+## Logging
+
+- Structured logging via `ILogger<T>` using source-generated `LoggerMessage` in a `*.Logging.cs` partial. Definitions are private/protected with a class-unique event id.
+
+## Testing
+
+- xUnit v3 on the Microsoft Testing Platform. Frameworks: NSubstitute (mocks), FluentAssertions, Neovolve.Streamline (`Tests<T>`/`TestsInternal`/`TestsPartsOf<T>`), Neovolve.Logging.Xunit.v3 (`output.BuildLoggerFor<T>()`), ModelBuilder.
+- Test class `<Type>Tests.cs`; method names have no underscores: `<Method><ExpectedResult>` or `<Method><ExpectedResult>When<Condition>` (use `Throws<T>` for exceptions).
+- Black-box only: do not widen accessibility to test; internals are reachable via `InternalsVisibleTo`. Prefer `[Theory]` over duplicate facts; vary inputs.
+- Assert observable behaviour, not logs — except to prove a security guarantee (no secrets/JWTs logged).
+- Build: `dotnet build Neovolve.Configuration.DependencyInjection.sln`. Test: `dotnet test Neovolve.Configuration.DependencyInjection.UnitTests\Neovolve.Configuration.DependencyInjection.UnitTests.csproj`. Coverage: `dotnet coverage collect "dotnet test <project> -f net10.0" -f cobertura -o cov.xml`.
+
+## Project configuration
+
+- SDK-style projects, shared props in [Directory.Build.props](../Directory.Build.props), central package versions in [Directory.Packages.props](../Directory.Packages.props). No hardcoded secrets.

--- a/.github/skills/update-dependencies/SKILL.md
+++ b/.github/skills/update-dependencies/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: update-dependencies
+description: Updates this repository's dependencies — the global.json .NET SDK version, NuGet package versions in Directory.Packages.props, and GitHub Actions versions in .github/workflows. Use when asked to update dependencies, bump packages, upgrade the SDK, refresh GitHub Actions, or check for outdated dependencies.
+---
+
+# Update dependencies
+
+Updates three dependency surfaces in `Neovolve.Configuration.DependencyInjection`, then validates with a build and test run. Make one logical commit per surface unless the user asks otherwise. Never push without being asked.
+
+## 1. .NET SDK (global.json)
+
+1. Read [global.json](../../../global.json) for the current `sdk.version`.
+2. Find the latest patch of that feature band: `dotnet sdk check`, or list installed with `dotnet --list-sdks`. Prefer the latest stable feature band that CI targets (`10.x`).
+3. Update `sdk.version`; keep `rollForward` and the `test.runner` block unchanged.
+
+## 2. NuGet packages (central versions)
+
+All versions are centrally pinned in [Directory.Packages.props](../../../Directory.Packages.props).
+
+1. List outdated packages: `dotnet list package --outdated`. Add `--include-transitive` to review pinned transitives.
+2. Bump `Version` attributes in `Directory.Packages.props`. Keep the per-TFM pins (e.g. `Microsoft.AspNetCore.Mvc.Testing`) aligned to their target framework conditions.
+3. Do not add or remove a pin for a package nothing references — only update versions that are actually consumed.
+
+## 3. GitHub Actions
+
+Pinned in `.github/workflows/*.yml` (e.g. `actions/checkout`, `actions/setup-dotnet`, `gittools/actions`).
+
+1. For each `uses: owner/repo@vN`, find the latest release tag: `gh release view --repo owner/repo` or `gh api repos/owner/repo/releases/latest --jq .tag_name` (without `gh`, fetch `https://github.com/owner/repo/releases/latest`). Compare against the pinned tag.
+2. Bump the major tag (e.g. `@v7`) when a newer one exists. Keep `dotnet-version` ranges (`8.x 9.x 10.x`) matching the target frameworks unless the SDK bump changes them.
+
+## 4. Validate
+
+```pwsh
+dotnet build Neovolve.Configuration.DependencyInjection.sln
+dotnet test Neovolve.Configuration.DependencyInjection.UnitTests\Neovolve.Configuration.DependencyInjection.UnitTests.csproj
+```
+
+Report what changed (old → new per item) and any majors skipped for being breaking. Temp files go under `.scratch/<session>/`.

--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Copilot temporary files
+.scratch/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="ModelBuilder" Version="8.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,8 +40,12 @@
   </ItemGroup>
   <ItemGroup Label="Source generator (Roslyn)">
     <!--
-      The generator builds against Roslyn 4.8 (via a VersionOverride in the generator project); this
-      repo-wide version is what the generator unit tests compile against to host the generator.
+      The generator builds against Roslyn 4.8 (via a VersionOverride in the generator project) because a
+      source generator runs inside the consumer's compiler, so its Microsoft.CodeAnalysis version sets the
+      minimum SDK a consumer needs. 4.8 is the floor covering every supported consumer TFM
+      (net472;net8.0;net9.0;net10.0) and netstandard2.0. This repo-wide version is what the generator unit
+      tests compile against to host the generator; ConfigureWithGeneratorTests.GeneratorTargetsSupportedRoslynFloor
+      fails if the generator's referenced Roslyn version is bumped above the 4.8 floor and silently drops support.
     -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <!-- The code fix unit tests host the fix in an AdhocWorkspace, which needs the Workspaces layer. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="ModelBuilder" Version="8.6.0" />
-    <PackageVersion Include="Neovolve.Streamline.NSubstitute" Version="2.4.1" />
+    <PackageVersion Include="Neovolve.Streamline.NSubstitute" Version="2.4.2" />
     <PackageVersion Include="Neovolve.Logging.Xunit.v3" Version="7.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!--

--- a/Neovolve.Configuration.DependencyInjection.Generator.UnitTests/ConfigureWithGeneratorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.Generator.UnitTests/ConfigureWithGeneratorTests.cs
@@ -193,6 +193,19 @@ namespace Sample
         thirdConfigType.GetProperty("ThirdValue")!.GetValue(injected).Should().Be("updated");
     }
 
+    // The generator builds against Roslyn 4.8 so it loads on every supported consumer SDK (net472, net8.0,
+    // net9.0, net10.0 and netstandard2.0). Bumping that floor silently drops support on older SDKs, so this
+    // test fails if the generator ever references a newer Microsoft.CodeAnalysis than the documented floor.
+    [Fact]
+    public void GeneratorTargetsSupportedRoslynFloor()
+    {
+        var reference = typeof(ConfigureWithGenerator).Assembly
+            .GetReferencedAssemblies()
+            .Single(name => name.Name == "Microsoft.CodeAnalysis");
+
+        reference.Version.Should().Be(new Version(4, 8, 0, 0));
+    }
+
     [Fact]
     public void DoesNotGenerateWhenNoConfigureWithInvocation()
     {

--- a/Neovolve.Configuration.DependencyInjection.IntegrationTests/InjectionTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.IntegrationTests/InjectionTests.cs
@@ -408,6 +408,9 @@ public sealed class InjectionTests
     {
         var newConfig = Model.Create<RootConfig>();
 
+        // Keep TimeoutInSeconds within the [Range(10, 120)] on ThirdConfig so the reload passes validation.
+        newConfig.First.Second.Third.TimeoutInSeconds = 60;
+
         var data = JsonConvert.SerializeObject(newConfig);
 
         _output.WriteLine("Updated disk config: " + data);

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigAttributesTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigAttributesTests.cs
@@ -1,0 +1,56 @@
+namespace Neovolve.Configuration.DependencyInjection.UnitTests;
+
+using FluentAssertions;
+using Neovolve.Configuration.DependencyInjection.Generated;
+using Xunit;
+
+public class ConfigAttributesTests
+{
+    [Fact]
+    public void GenerateConfigAccessorsDefaultsToEmptyTypes()
+    {
+        var sut = new GenerateConfigAccessorsAttribute();
+
+        sut.Types.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GenerateConfigAccessorsStoresSuppliedTypes()
+    {
+        var sut = new GenerateConfigAccessorsAttribute(typeof(string), typeof(int));
+
+        sut.Types.Should().Equal(typeof(string), typeof(int));
+    }
+
+    [Fact]
+    public void SkipConfigTypeDefaultsToEmptyTypes()
+    {
+        var sut = new SkipConfigTypeAttribute();
+
+        sut.Types.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SkipConfigTypeReplacesNullTypesWithEmpty()
+    {
+        var sut = new SkipConfigTypeAttribute(null!);
+
+        sut.Types.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SkipConfigTypeStoresSuppliedTypes()
+    {
+        var sut = new SkipConfigTypeAttribute(typeof(string));
+
+        sut.Types.Should().Equal(typeof(string));
+    }
+
+    [Fact]
+    public void SkipConfigPropertyCanBeConstructed()
+    {
+        var sut = new SkipConfigPropertyAttribute();
+
+        sut.Should().NotBeNull();
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigUpdateContextTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigUpdateContextTests.cs
@@ -1,0 +1,132 @@
+namespace Neovolve.Configuration.DependencyInjection.UnitTests;
+
+using System;
+using System.Collections.ObjectModel;
+using FluentAssertions;
+using Neovolve.Configuration.DependencyInjection;
+using Neovolve.Configuration.DependencyInjection.Generated;
+using Neovolve.Logging.Xunit;
+using Xunit;
+
+public class ConfigUpdateContextTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public ConfigUpdateContextTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void IsChangeLoggingEnabledReturnsFalseWhenNoLogger()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), null, new ConfigureWithOptions());
+
+        sut.IsChangeLoggingEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsChangeLoggingEnabledReturnsTrueWithLogger()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        sut.IsChangeLoggingEnabled.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(NestedChangeLogging.Deep, true)]
+    [InlineData(NestedChangeLogging.Summary, false)]
+    public void LogNestedChangesReflectsOption(NestedChangeLogging mode, bool expected)
+    {
+        var options = new ConfigureWithOptions { NestedChangeLogging = mode };
+
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), options);
+
+        sut.LogNestedChanges.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReportCountReturnsTrueWhenCountChanges()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        var previous = new Collection<string> { "a" };
+        var updated = new Collection<string> { "a", "b" };
+
+        sut.ReportCount("Items", previous, updated).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReportValueReturnsFalseWhenUnchanged()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        sut.ReportValue("Name", 1, 1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReportValueReturnsTrueWhenChanged()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        sut.ReportValue("Name", 1, 2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReportValuesReturnsTrueWhenElementChanges()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        sut.ReportValues("Items", new[] { "a" }, new[] { "b" }).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReportReadOnlyDoesNotThrowWhenNoneConfigured()
+    {
+        var options = new ConfigureWithOptions { LogReadOnlyPropertyType = LogReadOnlyPropertyType.None };
+
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), options);
+
+        var action = () => sut.ReportReadOnly("Name", true);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReportReadOnlyDoesNotThrowWhenAllConfigured()
+    {
+        var options = new ConfigureWithOptions { LogReadOnlyPropertyType = LogReadOnlyPropertyType.All };
+
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), options);
+
+        var action = () => sut.ReportReadOnly("Name", false);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReportCopyFailureDoesNotThrow()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        var action = () => sut.ReportCopyFailure("Name", new InvalidOperationException());
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReportCountReturnsFalseWhenUnchanged()
+    {
+        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
+
+        var previous = new Collection<string> { "a" };
+        var updated = new Collection<string> { "b" };
+
+        sut.ReportCount("Items", previous, updated).Should().BeFalse();
+    }
+
+    private ICacheLogger Logger()
+    {
+        return _output.BuildLogger();
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigUpdateContextTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/ConfigUpdateContextTests.cs
@@ -56,20 +56,14 @@ public class ConfigUpdateContextTests
         sut.ReportCount("Items", previous, updated).Should().BeTrue();
     }
 
-    [Fact]
-    public void ReportValueReturnsFalseWhenUnchanged()
+    [Theory]
+    [InlineData(1, 1, false)]
+    [InlineData(1, 2, true)]
+    public void ReportValueReturnsWhetherValueChanged(int previous, int updated, bool expected)
     {
         var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
 
-        sut.ReportValue("Name", 1, 1).Should().BeFalse();
-    }
-
-    [Fact]
-    public void ReportValueReturnsTrueWhenChanged()
-    {
-        var sut = new ConfigUpdateContext(typeof(string), Logger(), new ConfigureWithOptions());
-
-        sut.ReportValue("Name", 1, 2).Should().BeTrue();
+        sut.ReportValue("Name", previous, updated).Should().Be(expected);
     }
 
     [Fact]

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/DefaultConfigValidatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/DefaultConfigValidatorTests.cs
@@ -59,12 +59,21 @@ public class DefaultConfigValidatorTests
         sut.IsValid(new Target(), null, null).Should().BeTrue();
     }
 
-    [Fact]
-    public void ThrowOnInvalidDataAnnotationsDoesNotThrowWhenValid()
+    [Theory]
+    [InlineData(10, false)]
+    [InlineData(600, true)]
+    public void ThrowOnInvalidDataAnnotationsThrowsOnlyWhenInvalid(int value, bool shouldThrow)
     {
-        var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations(new Target { Value = 10 });
+        var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations(new Target { Value = value });
 
-        action.Should().NotThrow();
+        if (shouldThrow)
+        {
+            action.Should().Throw<OptionsValidationException>();
+        }
+        else
+        {
+            action.Should().NotThrow();
+        }
     }
 
     [Fact]
@@ -73,14 +82,6 @@ public class DefaultConfigValidatorTests
         var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations<Target>(null!);
 
         action.Should().NotThrow();
-    }
-
-    [Fact]
-    public void ThrowOnInvalidDataAnnotationsThrowsWhenInvalid()
-    {
-        var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations(new Target { Value = 600 });
-
-        action.Should().Throw<OptionsValidationException>();
     }
 
     [Fact]

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/DefaultConfigValidatorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/DefaultConfigValidatorTests.cs
@@ -1,0 +1,114 @@
+namespace Neovolve.Configuration.DependencyInjection.UnitTests;
+
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Neovolve.Configuration.DependencyInjection;
+using Neovolve.Logging.Xunit;
+using Xunit;
+
+public class DefaultConfigValidatorTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public DefaultConfigValidatorTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void IsValidReturnsFalseWhenValidatorFails()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IValidateOptions<Target>>(
+            new TestValidateOptions(ValidateOptionsResult.Fail("Failure")));
+
+        using var provider = services.BuildServiceProvider();
+
+        var sut = new DefaultConfigValidator(provider);
+
+        sut.IsValid(new Target(), null, _output.BuildLoggerFor<DefaultConfigValidator>()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidReturnsTrueWhenNoValidatorsRegistered()
+    {
+        var services = new ServiceCollection();
+
+        using var provider = services.BuildServiceProvider();
+
+        var sut = new DefaultConfigValidator(provider);
+
+        sut.IsValid(new Target(), null, null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidReturnsTrueWhenValidatorSucceeds()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IValidateOptions<Target>>(
+            new TestValidateOptions(ValidateOptionsResult.Success));
+
+        using var provider = services.BuildServiceProvider();
+
+        var sut = new DefaultConfigValidator(provider);
+
+        sut.IsValid(new Target(), null, null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ThrowOnInvalidDataAnnotationsDoesNotThrowWhenValid()
+    {
+        var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations(new Target { Value = 10 });
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowOnInvalidDataAnnotationsDoesNotThrowWhenValueIsNull()
+    {
+        var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations<Target>(null!);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowOnInvalidDataAnnotationsThrowsWhenInvalid()
+    {
+        var action = () => DefaultConfigValidator.ThrowOnInvalidDataAnnotations(new Target { Value = 600 });
+
+        action.Should().Throw<OptionsValidationException>();
+    }
+
+    [Fact]
+    public void ThrowsExceptionWithNullProvider()
+    {
+        var action = () => new DefaultConfigValidator(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    private class Target
+    {
+        [Range(5, 120)]
+        public int Value { get; set; } = 30;
+    }
+
+    private sealed class TestValidateOptions : IValidateOptions<Target>
+    {
+        private readonly ValidateOptionsResult _result;
+
+        public TestValidateOptions(ValidateOptionsResult result)
+        {
+            _result = result;
+        }
+
+        public ValidateOptionsResult Validate(string? name, Target options)
+        {
+            return _result;
+        }
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/GeneratedConfigRegistryTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/GeneratedConfigRegistryTests.cs
@@ -1,0 +1,102 @@
+namespace Neovolve.Configuration.DependencyInjection.UnitTests;
+
+using FluentAssertions;
+using NSubstitute;
+using Neovolve.Configuration.DependencyInjection.Generated;
+using Xunit;
+
+public class GeneratedConfigRegistryTests
+{
+    [Fact]
+    public void RegisterGraphThrowsWithNullRegistrar()
+    {
+        var action = () => GeneratedConfigRegistry.RegisterGraph(typeof(Target), null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RegisterGraphThrowsWithNullRootType()
+    {
+        var action = () => GeneratedConfigRegistry.RegisterGraph(null!, Substitute.For<IConfigGraphRegistrar>());
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RegisterApplierThrowsWithNullApplier()
+    {
+        var action = () => GeneratedConfigRegistry.RegisterApplier(typeof(Target), null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RegisterApplierThrowsWithNullConfigType()
+    {
+        var action = () => GeneratedConfigRegistry.RegisterApplier(null!, new object());
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryGetApplierReturnsFalseWhenNotRegistered()
+    {
+        GeneratedConfigRegistry.TryGetApplier<UnregisteredTarget>(out var applier).Should().BeFalse();
+        applier.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetApplierReturnsRegisteredApplier()
+    {
+        var applier = new TargetApplier();
+
+        GeneratedConfigRegistry.RegisterApplier(typeof(Target), applier);
+
+        GeneratedConfigRegistry.TryGetApplier<Target>(out var actual).Should().BeTrue();
+        actual.Should().BeSameAs(applier);
+    }
+
+    [Fact]
+    public void TryGetApplierThrowsWithNullConfigType()
+    {
+        var action = () => GeneratedConfigRegistry.TryGetApplier(null!, out _);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryGetRegistrarThrowsWithNullRootType()
+    {
+        var action = () => GeneratedConfigRegistry.TryGetRegistrar(null!, out _);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryGetRegistrarReturnsRegisteredRegistrar()
+    {
+        var registrar = Substitute.For<IConfigGraphRegistrar>();
+
+        GeneratedConfigRegistry.RegisterGraph(typeof(Target), registrar);
+
+        GeneratedConfigRegistry.TryGetRegistrar(typeof(Target), out var actual).Should().BeTrue();
+        actual.Should().BeSameAs(registrar);
+    }
+
+    private sealed class Target
+    {
+    }
+
+    private sealed class UnregisteredTarget
+    {
+    }
+
+    private sealed class TargetApplier : IConfigValueApplier<Target>
+    {
+        public bool Apply(Target injected, Target updated, IConfigUpdateContext context)
+        {
+            return false;
+        }
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection.UnitTests/ValidationTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/ValidationTests.cs
@@ -1,0 +1,66 @@
+namespace Neovolve.Configuration.DependencyInjection.UnitTests;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Neovolve.Configuration.DependencyInjection;
+using Xunit;
+
+public class ValidationTests
+{
+    [Fact]
+    public void ConfigureWithBindsWhenNestedValueIsInRange()
+    {
+        var services = new ServiceCollection();
+
+        services.ConfigureWith<ValidatedRootConfig>(BuildConfiguration(30));
+
+        using var provider = services.BuildServiceProvider();
+
+        var actual = provider.GetRequiredService<ValidatedChildConfig>();
+
+        actual.TimeoutInSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public void ConfigureWithThrowsWhenNestedValueIsOutOfRange()
+    {
+        var services = new ServiceCollection();
+
+        services.ConfigureWith<ValidatedRootConfig>(BuildConfiguration(600));
+
+        using var provider = services.BuildServiceProvider();
+
+        var action = () => provider.GetRequiredService<ValidatedChildConfig>();
+
+        action.Should().Throw<OptionsValidationException>();
+    }
+
+    private static IConfiguration BuildConfiguration(int timeoutInSeconds)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["RootValue"] = "root",
+                    ["Child:TimeoutInSeconds"] = timeoutInSeconds.ToString()
+                })
+            .Build();
+    }
+
+    public class ValidatedRootConfig
+    {
+        public ValidatedChildConfig Child { get; set; } = new();
+
+        public string RootValue { get; set; } = string.Empty;
+    }
+
+    public class ValidatedChildConfig
+    {
+        [Range(5, 120)]
+        public int TimeoutInSeconds { get; set; } = 30;
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection/DefaultConfigUpdater.Logging.cs
+++ b/Neovolve.Configuration.DependencyInjection/DefaultConfigUpdater.Logging.cs
@@ -5,7 +5,7 @@ namespace Neovolve.Configuration.DependencyInjection;
 
 using Microsoft.Extensions.Logging;
 
-public partial class DefaultConfigUpdater
+internal partial class DefaultConfigUpdater
 {
     private const string CopyValuesEventName = "Neovolve.Configuration.DependencyInjection.IConfigUpdater.UpdateConfig";
 

--- a/Neovolve.Configuration.DependencyInjection/DefaultConfigUpdater.cs
+++ b/Neovolve.Configuration.DependencyInjection/DefaultConfigUpdater.cs
@@ -8,7 +8,7 @@ using Neovolve.Configuration.DependencyInjection.Generated;
 ///     class provides the default implementation for updating injected configuration values when configuration data
 ///     changes.
 /// </summary>
-public partial class DefaultConfigUpdater : IConfigUpdater
+internal partial class DefaultConfigUpdater : IConfigUpdater
 {
     private readonly IConfigureWithOptions _options;
 

--- a/Neovolve.Configuration.DependencyInjection/DefaultConfigValidator.Logging.cs
+++ b/Neovolve.Configuration.DependencyInjection/DefaultConfigValidator.Logging.cs
@@ -1,0 +1,16 @@
+// We want the extension methods to be exposed when hosting is available in the calling application
+// ReSharper disable once CheckNamespace
+
+namespace Neovolve.Configuration.DependencyInjection;
+
+using System;
+using Microsoft.Extensions.Logging;
+
+internal partial class DefaultConfigValidator
+{
+    [LoggerMessage(EventId = 5002,
+        EventName = "Neovolve.Configuration.DependencyInjection.IConfigValidator:ValidationFailed",
+        Level = LogLevel.Error,
+        Message = "Configuration reload for {TargetType} was rejected because validation failed: {Failures}")]
+    static partial void LogValidationFailed(ILogger logger, Type targetType, string failures);
+}

--- a/Neovolve.Configuration.DependencyInjection/DefaultConfigValidator.cs
+++ b/Neovolve.Configuration.DependencyInjection/DefaultConfigValidator.cs
@@ -1,0 +1,113 @@
+namespace Neovolve.Configuration.DependencyInjection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    ///     The <see cref="DefaultConfigValidator" /> class runs the registered <see cref="IValidateOptions{TOptions}" />
+    ///     validators for a configuration type so reloads can be rejected when validation fails.
+    /// </summary>
+    /// <remarks>
+    ///     Validators are resolved from the service provider, so data annotation validation, source generated validators
+    ///     and custom <see cref="IValidateOptions{TOptions}" /> implementations all participate. When no validators are
+    ///     registered every value is treated as valid.
+    /// </remarks>
+    internal partial class DefaultConfigValidator : IConfigValidator
+    {
+        private readonly IServiceProvider _provider;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultConfigValidator" /> class.
+        /// </summary>
+        /// <param name="provider">The service provider used to resolve the registered validators.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="provider" /> parameter is <c>null</c>.</exception>
+        public DefaultConfigValidator(IServiceProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        /// <inheritdoc />
+        public bool IsValid<T>(T value, string? name, ILogger? logger) where T : class
+        {
+            var result = Run(value, name);
+
+            if (result == null || result.Succeeded)
+            {
+                return true;
+            }
+
+            if (logger != null)
+            {
+                LogValidationFailed(logger, typeof(T), string.Join("; ", result.Failures ?? Array.Empty<string>()));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Validates a configuration value's data annotation attributes, throwing when validation fails.
+        /// </summary>
+        /// <typeparam name="T">The configuration type being validated.</typeparam>
+        /// <param name="value">The configuration value to validate.</param>
+        /// <exception cref="OptionsValidationException">Validation failed for one or more data annotation attributes.</exception>
+        internal static void ThrowOnInvalidDataAnnotations<T>(T value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            var results = new List<ValidationResult>();
+            var context = new ValidationContext(value);
+
+            if (Validator.TryValidateObject(value, context, results, true))
+            {
+                return;
+            }
+
+            var failures = new List<string>();
+
+            foreach (var result in results)
+            {
+                failures.Add(result.ErrorMessage ?? "Validation failed.");
+            }
+
+            throw new OptionsValidationException(Options.DefaultName, typeof(T), failures);
+        }
+
+        private ValidateOptionsResult? Run<T>(T value, string? name) where T : class
+        {
+            var validators = _provider.GetServices<IValidateOptions<T>>();
+            var ran = false;
+            var failures = new List<string>();
+
+            foreach (var validator in validators)
+            {
+                ran = true;
+
+                var result = validator.Validate(name, value);
+
+                if (result.Failed)
+                {
+                    failures.AddRange(result.Failures);
+                }
+            }
+
+            if (ran == false)
+            {
+                return null;
+            }
+
+            if (failures.Count > 0)
+            {
+                return ValidateOptionsResult.Fail(failures);
+            }
+
+            return ValidateOptionsResult.Success;
+        }
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection/Generated/GeneratedConfigSupport.cs
+++ b/Neovolve.Configuration.DependencyInjection/Generated/GeneratedConfigSupport.cs
@@ -30,6 +30,10 @@ namespace Neovolve.Configuration.DependencyInjection.Generated
         {
             var value = configuration.Get<TRoot>()!;
 
+            // The root type bypasses the options pipeline, so enforce data annotation validation here to fail fast on
+            // startup when the bound root configuration is invalid.
+            DefaultConfigValidator.ThrowOnInvalidDataAnnotations(value);
+
             services.AddSingleton(value);
 
             // The default configuration support registers IOptions<T> and related interfaces that just return a new
@@ -101,6 +105,9 @@ namespace Neovolve.Configuration.DependencyInjection.Generated
             where T : struct
         {
             var value = section.Get<T>();
+
+            // A struct also bypasses the options pipeline, so validate it on startup to fail fast on invalid values.
+            DefaultConfigValidator.ThrowOnInvalidDataAnnotations(value);
 
             // Box once so the concrete type and all its interfaces resolve to the same instance.
             object boxed = value;

--- a/Neovolve.Configuration.DependencyInjection/IConfigValidator.cs
+++ b/Neovolve.Configuration.DependencyInjection/IConfigValidator.cs
@@ -1,0 +1,21 @@
+namespace Neovolve.Configuration.DependencyInjection
+{
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    ///     The <see cref="IConfigValidator" /> interface defines validation of reloaded configuration values so invalid
+    ///     reloads can be rejected before they are applied.
+    /// </summary>
+    public interface IConfigValidator
+    {
+        /// <summary>
+        ///     Determines whether a reloaded configuration value is valid, logging any validation failures.
+        /// </summary>
+        /// <typeparam name="T">The configuration type being validated.</typeparam>
+        /// <param name="value">The configuration value to validate.</param>
+        /// <param name="name">The named options instance, or <c>null</c> for the default instance.</param>
+        /// <param name="logger">The logger used to report validation failures.</param>
+        /// <returns><c>true</c> if the value is valid; otherwise <c>false</c>.</returns>
+        bool IsValid<T>(T value, string? name, ILogger? logger) where T : class;
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection/Neovolve.Configuration.DependencyInjection.csproj
+++ b/Neovolve.Configuration.DependencyInjection/Neovolve.Configuration.DependencyInjection.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Options" />
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+		<PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Neovolve.Configuration.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Neovolve.Configuration.DependencyInjection/ServiceCollectionExtensions.cs
@@ -104,6 +104,9 @@ public static class ServiceCollectionExtensions
         // Add the default configuration updater if one is not already registered
         services.TryAddTransient<IConfigUpdater, DefaultConfigUpdater>();
 
+        // Add the default configuration validator if one is not already registered
+        services.TryAddSingleton<IConfigValidator, DefaultConfigValidator>();
+
         if (GeneratedConfigRegistry.TryGetRegistrar(typeof(T), out var registrar) == false)
         {
             throw new InvalidOperationException(

--- a/Neovolve.Configuration.DependencyInjection/TypeRegistrationExtensions.cs
+++ b/Neovolve.Configuration.DependencyInjection/TypeRegistrationExtensions.cs
@@ -51,8 +51,11 @@
         public static IServiceCollection RegisterConfigType<T>(this IServiceCollection services,
             IConfigurationSection section) where T : class
         {
-            // Configure this type so that we can get access to IOptions<T>, IOptionsSnapshot<T> and IOptionsMonitor<T>
-            services.Configure<T>(section);
+            // Bind the type through the options pipeline and enforce data annotation validation at startup so invalid
+            // configuration fails fast instead of silently binding. Validation runs through any registered
+            // IValidateOptions<T> (data annotations here, plus source generated or custom validators), keeping the
+            // path reflection free for AOT when source generated validators are supplied.
+            services.AddOptions<T>().Bind(section).ValidateDataAnnotations().ValidateOnStart();
 
             // Configure the injection of T as a single instance
             // We want this to be a singleton so that we have a single instance that we can update when configuration changes
@@ -71,8 +74,6 @@
                     // This will work because the classes are reference types
                     monitor.OnChange((config, name) =>
                     {
-                        var updater = c.GetRequiredService<IConfigUpdater>();
-
                         // Figure out the logger to use
                         var factory = c.GetService<ILoggerFactory>();
                         ILogger? logger = null;
@@ -95,6 +96,18 @@
                                                               + ".ConfigureWith");
                             }
                         }
+
+                        // Validate the reloaded configuration before applying it. A failed reload keeps the previously
+                        // valid configuration so partial, fragmented updates are never applied (all-or-nothing).
+                        var validator = c.GetService<IConfigValidator>();
+
+                        if (validator != null
+                            && validator.IsValid(config, name, logger) == false)
+                        {
+                            return;
+                        }
+
+                        var updater = c.GetRequiredService<IConfigUpdater>();
 
                         updater.UpdateConfig(injectedValue, config, name, logger);
                     });

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ The **Neovolve.Configuration.DependencyInjection** NuGet package provides `IHost
 
 [![Actions Status](https://github.com/roryprimrose/Neovolve.Configuration.DependencyInjection/workflows/CI/badge.svg)](https://github.com/roryprimrose/Neovolve.Configuration.DependencyInjection/actions)
 
+# Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Hot reload support](#hot-reload-support)
+  - [Configuration types must be mutable classes to hot reload](#configuration-types-must-be-mutable-classes-to-hot-reload)
+- [Configuration validation](#configuration-validation)
+  - [Fail on start](#fail-on-start)
+  - [Validation on hot reload](#validation-on-hot-reload)
+- [Options](#options)
+- [Source generator](#source-generator)
+  - [Excluding properties and types](#excluding-properties-and-types)
+- [Recommendations](#recommendations)
+  - [Use read-only interface definitions for configuration types](#use-read-only-interface-definitions-for-configuration-types)
+  - [Properties for child configuration types should be classes](#properties-for-child-configuration-types-should-be-classes)
+  - [Avoid resolving the root config service](#avoid-resolving-the-root-config-service)
+
 # Installation
 
 The package can be installed from NuGet using 
@@ -165,6 +182,31 @@ public struct StartupOnlySettings
 ```
 
 The warning can also be disabled project-wide with `<NoWarn>$(NoWarn);NCDI001</NoWarn>`.
+
+# Configuration validation
+`ConfigureWith<T>` enforces validation on the configuration graph so invalid configuration is rejected rather than silently bound. Validation runs through the standard options validation pipeline, so every validation source that produces an `IValidateOptions<T>` participates:
+
+- **Data annotation attributes** (`[Range]`, `[Required]`, `[StringLength]`, and so on) on configuration properties are validated automatically. Each child configuration type is bound with `ValidateDataAnnotations()`, and the root type and any struct types are validated with their data annotation attributes as they are bound.
+- **Source generated validators** declared with `[OptionsValidator]` on a partial `IValidateOptions<T>` implementation. This keeps validation reflection free and AOT friendly. Register the validator as `IValidateOptions<T>` so the library picks it up.
+- **Custom validators** registered as `IValidateOptions<T>` for rules that cannot be expressed as attributes.
+
+```csharp
+public class ThirdConfig : IThirdConfig
+{
+    [Range(5, 120)]
+    public int TimeoutInSeconds { get; set; } = 30;
+
+    public TimeSpan Timeout => TimeSpan.FromSeconds(TimeoutInSeconds);
+}
+```
+
+## Fail on start
+Invalid configuration fails fast at application startup. Child types are validated through `ValidateOnStart()`, while the root and struct configuration types are validated as they are bound. A failure throws an `OptionsValidationException` so the host does not start with invalid configuration.
+
+## Validation on hot reload
+When a configuration change is detected, the reloaded values are validated before being applied to the injected raw types. If validation fails, the change is rejected as a whole: the failure is logged and the previously valid configuration is retained, so a single invalid value never produces a fragmented update where some properties change and others do not. A reload that passes validation is applied as normal.
+
+To supply your own validation behaviour, register a custom `IConfigValidator` before calling `ConfigureWith<T>`; the default implementation runs the registered `IValidateOptions<T>` validators.
 
 # Options
 The following are the default options that `ConfigureWith<T>` uses.

--- a/TestHost/Config.cs
+++ b/TestHost/Config.cs
@@ -1,6 +1,7 @@
 ﻿namespace TestHost;
 
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
 
 public interface IConfig
 {
@@ -11,6 +12,7 @@ public class Config : IConfig
 {
     public FirstConfig First { get; } = new();
 
+    [Required]
     public string RootValue { get; set; } = string.Empty;
 }
 
@@ -54,5 +56,7 @@ public class ThirdConfig : IThirdConfig
     public string ThirdValue { get; set; } = string.Empty;
 
     public TimeSpan Timeout => TimeSpan.FromSeconds(TimeoutInSeconds);
+
+    [Range(10, 120)]
     public int TimeoutInSeconds { get; set; } = 123;
 }

--- a/TestHost/appsettings.json
+++ b/TestHost/appsettings.json
@@ -3,7 +3,7 @@
     "Second": {
       "Third": {
         "ThirdValue": "This is the third value",
-        "TimeoutInSeconds": 6
+        "TimeoutInSeconds": 30
       },
       "SecondValue": "This is the second value",
       "MoreValues": ["first", "second", "third"]

--- a/WebTestHost/RootConfig.cs
+++ b/WebTestHost/RootConfig.cs
@@ -56,5 +56,7 @@ public class ThirdConfig : IThirdConfig
     public string ThirdValue { get; set; } = string.Empty;
 
     public TimeSpan Timeout => TimeSpan.FromSeconds(TimeoutInSeconds);
+    
+    [Range(10, 120)]
     public int TimeoutInSeconds { get; set; } = 123;
 }

--- a/WebTestHost/RootConfig.cs
+++ b/WebTestHost/RootConfig.cs
@@ -1,6 +1,7 @@
 ﻿namespace WebTestHost;
 
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
 
 public interface IConfig
 {
@@ -11,6 +12,7 @@ public class RootConfig : IConfig
 {
     public FirstConfig First { get; } = new();
 
+    [Required]
     public string RootValue { get; set; } = string.Empty;
 }
 

--- a/WebTestHost/appsettings.json
+++ b/WebTestHost/appsettings.json
@@ -3,7 +3,7 @@
     "Second": {
       "Third": {
         "ThirdValue": "This is the third value",
-        "TimeoutInSeconds": 123
+        "TimeoutInSeconds": 30
       },
       "SecondValue": "This is the second value"
     },


### PR DESCRIPTION
Closes #77.

## Summary
Configuration types registered via `ConfigureWith<T>()` now have validation enforced across the graph, reflection-free where source-generated validators are supplied.

## Changes
- **Auto-registered data annotation validation** per child type via `AddOptions<T>().Bind().ValidateDataAnnotations().ValidateOnStart()`; root and struct types validate on bind.
- **Fail-on-start**: invalid configuration throws `OptionsValidationException` at startup rather than binding silently.
- **All-or-nothing hot reload**: `IConfigValidator`/`DefaultConfigValidator` run registered `IValidateOptions<T>` (data annotations, `[OptionsValidator]` source-gen, or custom) before applying; a failed reload is logged and the previous valid config is retained.
- `IConfigValidator` is the public extensibility seam; `DefaultConfigValidator`/`DefaultConfigUpdater` are internal.
- README validation section + TOC; repo copilot-instructions; `update-dependencies` skill.
- Generator floor guard: `GeneratorTargetsSupportedRoslynFloor` fails if the generator's referenced Roslyn moves above the 4.8 floor (net472/net8/net9/net10/netstandard2.0 support).
- Streamline test package bump 2.4.1 → 2.4.2.

## Validation sources supported
Data annotations, source-generated `[OptionsValidator]`, and custom `IValidateOptions<T>`.

## Tests
675 unit, 234 integration, 17 generator — all pass.