### PR TITLE
Bump Swashbuckle to 10.2.3 and block Roslyn major dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # The source generator must stay on Roslyn 4.x so it loads on every supported consumer SDK
+      # (net472, net8.0, net9.0, net10.0, netstandard2.0). A 5.x bump raises the floor and silently
+      # drops older-SDK support, so block major updates. GeneratorTargetsSupportedRoslynFloor enforces 4.8.
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.28" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.17" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <!-- Overrides -->
   </ItemGroup>
   <ItemGroup Label="Source generator (Roslyn)">


### PR DESCRIPTION
Bumps `Swashbuckle.AspNetCore` 9.0.6 → 10.2.3 and adds dependabot ignore rules blocking `version-update:semver-major` for `Microsoft.CodeAnalysis.CSharp`/`.Workspaces` to protect the generator's Roslyn 4.8 floor (enforced by `GeneratorTargetsSupportedRoslynFloor`). Build + 78 integration tests pass.