### PR TITLE
Add IHostApplicationBuilder extension support

### DIFF
--- a/Neovolve.Configuration.DependencyInjection.UnitTests/HostBuilderExtensionsTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.UnitTests/HostBuilderExtensionsTests.cs
@@ -109,7 +109,7 @@ public class HostBuilderExtensionsTests
     [Fact]
     public void ConfigureWithOptionsThrowsExceptionWithNullBuilder()
     {
-        Action action = () => HostBuilderExtensions.ConfigureWith<Config>(null!, _ => { });
+        Action action = () => HostBuilderExtensions.ConfigureWith<Config>((IHostBuilder)null!, _ => { });
 
         action.Should().Throw<ArgumentNullException>();
     }
@@ -270,7 +270,7 @@ public class HostBuilderExtensionsTests
     [Fact]
     public void ConfigureWithReloadThrowsExceptionWithNullBuilder()
     {
-        Action action = () => HostBuilderExtensions.ConfigureWith<Config>(null!, false);
+        Action action = () => HostBuilderExtensions.ConfigureWith<Config>((IHostBuilder)null!, false);
 
         action.Should().Throw<ArgumentNullException>();
     }
@@ -314,8 +314,97 @@ public class HostBuilderExtensionsTests
     [Fact]
     public void ConfigureWithThrowsExceptionWithNullBuilder()
     {
-        Action action = () => HostBuilderExtensions.ConfigureWith<Config>(null!);
+        Action action = () => HostBuilderExtensions.ConfigureWith<Config>((IHostBuilder)null!);
 
         action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ConfigureWithApplicationBuilderRegistersRootConfig()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.Configuration.AddInMemoryCollection(BuildConfigData());
+
+        builder.ConfigureWith<Config>();
+
+        using var host = builder.Build();
+
+        var actual = host.Services.GetRequiredService<Config>();
+
+        actual.RootValue.Should().Be("This is the root value");
+        actual.First.FirstValue.Should().Be("This is the first value");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConfigureWithApplicationBuilderRegistersReloadOptions(bool reloadInjectedRawTypes)
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.Configuration.AddInMemoryCollection(BuildConfigData());
+
+        builder.ConfigureWith<Config>(reloadInjectedRawTypes);
+
+        using var host = builder.Build();
+
+        var actual = host.Services.GetRequiredService<IConfigureWithOptions>();
+
+        actual.ReloadInjectedRawTypes.Should().Be(reloadInjectedRawTypes);
+    }
+
+    [Fact]
+    public void ConfigureWithApplicationBuilderRegistersProvidedOptions()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.Configuration.AddInMemoryCollection(BuildConfigData());
+
+        builder.ConfigureWith<Config>(x => { x.CustomLogCategory = "MyCategory"; });
+
+        using var host = builder.Build();
+
+        var actual = host.Services.GetRequiredService<IConfigureWithOptions>();
+
+        actual.CustomLogCategory.Should().Be("MyCategory");
+    }
+
+    [Fact]
+    public void ConfigureWithApplicationBuilderThrowsExceptionWithNullBuilder()
+    {
+        Action action = () => HostBuilderExtensions.ConfigureWith<Config>((IHostApplicationBuilder)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ConfigureWithApplicationBuilderReloadThrowsExceptionWithNullBuilder()
+    {
+        Action action = () => HostBuilderExtensions.ConfigureWith<Config>((IHostApplicationBuilder)null!, false);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ConfigureWithApplicationBuilderOptionsThrowsExceptionWithNullBuilder()
+    {
+        Action action = () => HostBuilderExtensions.ConfigureWith<Config>((IHostApplicationBuilder)null!, _ => { });
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    private static Dictionary<string, string?> BuildConfigData()
+    {
+        return new Dictionary<string, string?>
+        {
+            ["RootValue"] = "This is the root value",
+            ["First:FirstValue"] = "This is the first value",
+            ["First:Second:SecondValue"] = "This is the second value",
+            ["First:Second:MoreValues:First"] = "First",
+            ["First:Second:MoreValues:Second"] = "Second",
+            ["First:Second:MoreValues:Third"] = "Third",
+            ["First:Second:Third:ThirdValue"] = "This is the third value"
+        };
     }
 }

--- a/Neovolve.Configuration.DependencyInjection/HostBuilderExtensions.cs
+++ b/Neovolve.Configuration.DependencyInjection/HostBuilderExtensions.cs
@@ -83,4 +83,80 @@ public static class HostBuilderExtensions
         return builder.ConfigureServices((context, services) =>
             services.ConfigureWith<T>(context.Configuration, configure));
     }
+
+    /// <summary>
+    ///     The <see cref="ConfigureWith{T}(IHostApplicationBuilder)" /> method is used to configure the host application
+    ///     builder with
+    ///     configuration binding of type
+    ///     <typeparamref name="T" />
+    ///     and all its child types with hot reloading configuration changes onto injected raw configuration types.
+    /// </summary>
+    /// <typeparam name="T">The type of configuration to register.</typeparam>
+    /// <param name="builder">The host application builder to configure.</param>
+    /// <returns>The configured host application builder.</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="builder" /> parameter is <c>null</c>.</exception>
+    /// <remarks>
+    ///     This method adds options of type <typeparamref name="T" /> to the service collection and registers the
+    ///     configuration root of type <typeparamref name="T" /> and all child types found.
+    ///     The injected raw types defined in the configuration type will support hot reloading of updated configuration.
+    /// </remarks>
+    public static IHostApplicationBuilder ConfigureWith<T>(this IHostApplicationBuilder builder) where T : class
+    {
+        _ = builder ?? throw new ArgumentNullException(nameof(builder));
+
+        return ConfigureWith<T>(builder, _ => { });
+    }
+
+    /// <summary>
+    ///     The <see cref="ConfigureWith{T}(IHostApplicationBuilder, bool)" /> method is used to configure the host
+    ///     application builder with
+    ///     configuration binding of type
+    ///     <typeparamref name="T" />
+    ///     and all its child types.
+    /// </summary>
+    /// <typeparam name="T">The type of configuration to register.</typeparam>
+    /// <param name="builder">The host application builder to configure.</param>
+    /// <param name="reloadInjectedRawTypes"><c>true</c> if hot reloading raw types is enabled; otherwise <c>false</c>.</param>
+    /// <returns>The configured host application builder.</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="builder" /> parameter is <c>null</c>.</exception>
+    /// <remarks>
+    ///     This method adds options of type <typeparamref name="T" /> to the service collection and registers the
+    ///     configuration root of type <typeparamref name="T" />
+    ///     and all child types found.
+    ///     If <paramref name="reloadInjectedRawTypes" /> is <c>true</c>, the injected raw types defined in the configuration
+    ///     type
+    ///     will support hot reloading of updated configuration.
+    /// </remarks>
+    public static IHostApplicationBuilder ConfigureWith<T>(this IHostApplicationBuilder builder,
+        bool reloadInjectedRawTypes) where T : class
+    {
+        _ = builder ?? throw new ArgumentNullException(nameof(builder));
+
+        return ConfigureWith<T>(builder, x => { x.ReloadInjectedRawTypes = reloadInjectedRawTypes; });
+    }
+
+    /// <summary>
+    ///     The <see cref="ConfigureWith{T}(IHostApplicationBuilder, Action&lt;ConfigureWithOptions&gt;)" /> method is used to
+    ///     configure
+    ///     the host application builder with
+    ///     configuration binding of type
+    ///     <typeparamref name="T" />
+    ///     and all its child types.
+    /// </summary>
+    /// <typeparam name="T">The type of configuration to register.</typeparam>
+    /// <param name="builder">The host application builder to configure.</param>
+    /// <param name="configure">The configuration options action.</param>
+    /// <returns>The configured host application builder.</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="builder" /> parameter is <c>null</c>.</exception>
+    public static IHostApplicationBuilder ConfigureWith<T>(this IHostApplicationBuilder builder,
+        Action<ConfigureWithOptions> configure) where T : class
+    {
+        _ = builder ?? throw new ArgumentNullException(nameof(builder));
+
+        // The host application builder exposes the service collection and configuration directly, so the
+        // registration is delegated to the IServiceCollection overload, which is the core of the library.
+        builder.Services.ConfigureWith<T>(builder.Configuration, configure);
+
+        return builder;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -123,7 +123,15 @@ var builder = Host.CreateDefaultBuilder()
     .ConfigureWith<RootConfig>();
 ```
 
-Using `IHostBuilder` is the recommended way to use this library. For scenarios that work directly with an `IServiceCollection` and an `IConfiguration`, an equivalent overload is available. The `IHostBuilder` extension methods are thin wrappers over these.
+When using the modern host application builder (for example `Host.CreateApplicationBuilder()` or `WebApplication.CreateBuilder()`), the same extension method is available directly on the `IHostApplicationBuilder`:
+
+```csharp
+var builder = Host.CreateApplicationBuilder();
+
+builder.ConfigureWith<RootConfig>();
+```
+
+Using `IHostBuilder` or `IHostApplicationBuilder` is the recommended way to use this library. For scenarios that work directly with an `IServiceCollection` and an `IConfiguration`, an equivalent overload is available. The host builder extension methods are thin wrappers over these.
 
 ```csharp
 builder.Services.ConfigureWith<RootConfig>(builder.Configuration);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# Introduction
 
-The **Neovolve.Configuration.DependencyInjection** NuGet package provides `IHostBuilder` and `IServiceCollection` extension methods for registering strong typed configuration bindings as services. It supports registration of nested configuration types and hot reload support.
+The **Neovolve.Configuration.DependencyInjection** NuGet package provides `IHostApplicationBuilder`, `IHostBuilder` and `IServiceCollection` extension methods for registering strong typed configuration bindings as services. It supports registration of nested configuration types and hot reload support.
 
 [![GitHub license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/roryprimrose/Neovolve.Configuration.DependencyInjection/blob/master/LICENSE)&nbsp;&nbsp;&nbsp;[![Nuget](https://img.shields.io/nuget/v/Neovolve.Configuration.DependencyInjection.svg)&nbsp;&nbsp;&nbsp;![Nuget](https://img.shields.io/nuget/dt/Neovolve.Configuration.DependencyInjection.svg)](https://www.nuget.org/packages/Neovolve.Configuration.DependencyInjection)
 
@@ -113,17 +113,10 @@ For an ASP.Net system, this would be registered like the following:
 var builder = WebApplication.CreateBuilder(args);
 
 // Register all configuration types
-builder.Host.ConfigureWith<RootConfig>();
+builder.ConfigureWith<RootConfig>();
 ```
 
-For other platforms, such as console applications, this would be registered like the following:
-
-```csharp
-var builder = Host.CreateDefaultBuilder()
-    .ConfigureWith<RootConfig>();
-```
-
-When using the modern host application builder (for example `Host.CreateApplicationBuilder()` or `WebApplication.CreateBuilder()`), the same extension method is available directly on the `IHostApplicationBuilder`:
+For other platforms, such as console applications, the host application builder is registered like the following:
 
 ```csharp
 var builder = Host.CreateApplicationBuilder();
@@ -131,7 +124,14 @@ var builder = Host.CreateApplicationBuilder();
 builder.ConfigureWith<RootConfig>();
 ```
 
-Using `IHostBuilder` or `IHostApplicationBuilder` is the recommended way to use this library. For scenarios that work directly with an `IServiceCollection` and an `IConfiguration`, an equivalent overload is available. The host builder extension methods are thin wrappers over these.
+Using `IHostApplicationBuilder` (returned by `WebApplication.CreateBuilder()` and `Host.CreateApplicationBuilder()`) is the recommended way to use this library. The classic `IHostBuilder` is also supported for applications still using `Host.CreateDefaultBuilder()`:
+
+```csharp
+var builder = Host.CreateDefaultBuilder()
+    .ConfigureWith<RootConfig>();
+```
+
+For scenarios that work directly with an `IServiceCollection` and an `IConfiguration`, an equivalent overload is available. The host builder extension methods are thin wrappers over these.
 
 ```csharp
 builder.Services.ConfigureWith<RootConfig>(builder.Configuration);


### PR DESCRIPTION
Fixes #71

## Summary

The extension methods previously only supported `IHostBuilder`. The modern minimal-hosting builders (`Host.CreateApplicationBuilder()`, `WebApplication.CreateBuilder()`) return `IHostApplicationBuilder`, forcing consumers to call `builder.Services.ConfigureWith<T>(builder.Configuration)`. This adds first-class `IHostApplicationBuilder` overloads.

## Changes

- Added three `ConfigureWith<T>` overloads on `IHostApplicationBuilder` (parameterless, `bool reloadInjectedRawTypes`, and `Action<ConfigureWithOptions>`), mirroring the existing `IHostBuilder` overloads. They delegate to the `IServiceCollection` overload via `builder.Services`/`builder.Configuration`.
- Added unit tests for the new overloads (registration, reload option, configure action, and null-builder guards). Disambiguated existing null-builder tests with explicit `IHostBuilder` casts.
- Updated README with the `IHostApplicationBuilder` usage example.

Compiles on all targets (netstandard2.0, net8.0, net9.0, net10.0). All 231 unit tests pass.