### PR TITLE
Report read-only collection properties with NCDI002 instead of NCDI001

### DIFF
--- a/Neovolve.Configuration.DependencyInjection.CodeFixes.UnitTests/ReadOnlyCollectionCodeFixProviderTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.CodeFixes.UnitTests/ReadOnlyCollectionCodeFixProviderTests.cs
@@ -1,0 +1,227 @@
+namespace Neovolve.Configuration.DependencyInjection.CodeFixes.UnitTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Xunit;
+
+    public class ReadOnlyCollectionCodeFixProviderTests
+    {
+        private const string AddSetterTitle = "Add a setter to support hot reload";
+
+        private const string SkipPropertyTitle = "Exclude the property from hot reload with [SkipConfigProperty]";
+
+        private static readonly DiagnosticDescriptor _descriptor = new(
+            "NCDI002",
+            "Read-only collection configuration property cannot be hot reloaded",
+            "Configuration property '{0}' is a read-only collection",
+            "Neovolve.Configuration",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        [Fact]
+        public async Task OffersBothFixesForGetOnlyCollectionProperty()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    public sealed class RequiredDataConfig
+    {
+        public ICollection<string> RequiredData { get; } = new Collection<string>();
+    }
+}";
+
+            var actions = await GetActions(source, "RequiredData");
+
+            actions.Select(action => action.Title).Should().Contain(new[] { AddSetterTitle, SkipPropertyTitle });
+        }
+
+        [Fact]
+        public async Task AddsSetterToGetOnlyProperty()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    public sealed class RequiredDataConfig
+    {
+        public ICollection<string> RequiredData { get; } = new Collection<string>();
+    }
+}";
+
+            var fixedText = await ApplyFix(source, "RequiredData", AddSetterTitle);
+
+            fixedText.Should().Contain("public ICollection<string> RequiredData { get; set; }");
+        }
+
+        [Fact]
+        public async Task PreservesInitializerWhenAddingSetter()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    public sealed class RequiredDataConfig
+    {
+        public ICollection<string> RequiredData { get; } = new Collection<string>();
+    }
+}";
+
+            var fixedText = await ApplyFix(source, "RequiredData", AddSetterTitle);
+
+            fixedText.Should().Contain("= new Collection<string>();");
+        }
+
+        [Fact]
+        public async Task AppliesSkipConfigPropertyAttribute()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    public sealed class RequiredDataConfig
+    {
+        public ICollection<string> RequiredData { get; } = new Collection<string>();
+    }
+}";
+
+            var fixedText = await ApplyFix(source, "RequiredData", SkipPropertyTitle);
+
+            fixedText.Should().Contain("[SkipConfigProperty]");
+            fixedText.Should().Contain("using Neovolve.Configuration.DependencyInjection.Generated;");
+            fixedText.Should().Contain("public ICollection<string> RequiredData { get; } = new Collection<string>();");
+        }
+
+        [Fact]
+        public async Task AppliesSkipConfigPropertyAttributeToExpressionBodiedProperty()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+
+    public sealed class RequiredDataConfig
+    {
+        private readonly ICollection<string> _data = new List<string>();
+        public ICollection<string> RequiredData => _data;
+    }
+}";
+
+            var fixedText = await ApplyFix(source, "RequiredData", SkipPropertyTitle);
+
+            fixedText.Should().Contain("[SkipConfigProperty]");
+        }
+
+        [Fact]
+        public async Task DoesNotOfferAddSetterWhenSetterAlreadyPresent()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+
+    public sealed class RequiredDataConfig
+    {
+        public ICollection<string> RequiredData { get; set; } = new List<string>();
+    }
+}";
+
+            var actions = await GetActions(source, "RequiredData");
+
+            actions.Select(action => action.Title).Should().NotContain(AddSetterTitle);
+        }
+
+        [Fact]
+        public async Task DoesNotOfferAddSetterForExpressionBodiedProperty()
+        {
+            const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+
+    public sealed class RequiredDataConfig
+    {
+        private readonly ICollection<string> _data = new List<string>();
+        public ICollection<string> RequiredData => _data;
+    }
+}";
+
+            var actions = await GetActions(source, "RequiredData");
+
+            actions.Select(action => action.Title).Should().NotContain(AddSetterTitle);
+        }
+
+        private static async Task<IReadOnlyList<CodeAction>> GetActions(string source, string propertyName)
+        {
+            var workspace = new AdhocWorkspace();
+
+            var project = workspace.CurrentSolution
+                .AddProject("Test", "Test", LanguageNames.CSharp)
+                .WithCompilationOptions(
+                    new CSharpCompilationOptions(
+                        OutputKind.DynamicallyLinkedLibrary,
+                        nullableContextOptions: NullableContextOptions.Enable))
+                .WithParseOptions(new CSharpParseOptions(LanguageVersion.Latest));
+
+            var document = project.AddDocument("Test.cs", source);
+
+            var root = await document.GetSyntaxRootAsync(CancellationToken.None);
+            root.Should().NotBeNull();
+
+            var declaration = root!.DescendantNodes()
+                .OfType<PropertyDeclarationSyntax>()
+                .Single(node => node.Identifier.ValueText == propertyName);
+
+            var diagnostic = Diagnostic.Create(_descriptor, Location.Create(root.SyntaxTree, declaration.Span),
+                propertyName);
+
+            var provider = new ReadOnlyCollectionCodeFixProvider();
+            var actions = new List<CodeAction>();
+
+            var context = new CodeFixContext(
+                document,
+                diagnostic,
+                (action, _) => actions.Add(action),
+                CancellationToken.None);
+
+            await provider.RegisterCodeFixesAsync(context);
+
+            return actions;
+        }
+
+        private static async Task<string> ApplyFix(string source, string propertyName, string title)
+        {
+            var actions = await GetActions(source, propertyName);
+
+            var action = actions.Single(candidate => candidate.Title == title);
+
+            var operations = await action.GetOperationsAsync(CancellationToken.None);
+            var applyChanges = operations.OfType<ApplyChangesOperation>().Single();
+
+            var changedDocument = applyChanges.ChangedSolution.Projects
+                .Single()
+                .Documents
+                .Single();
+
+            var text = await changedDocument.GetTextAsync();
+
+            return text.ToString();
+        }
+    }
+}

--- a/Neovolve.Configuration.DependencyInjection.CodeFixes/ReadOnlyCollectionCodeFixProvider.cs
+++ b/Neovolve.Configuration.DependencyInjection.CodeFixes/ReadOnlyCollectionCodeFixProvider.cs
@@ -1,0 +1,187 @@
+namespace Neovolve.Configuration.DependencyInjection.CodeFixes
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    /// <summary>
+    ///     The <see cref="ReadOnlyCollectionCodeFixProvider" /> class offers fixes for a read only collection
+    ///     configuration property that cannot be hot reloaded.
+    /// </summary>
+    /// <remarks>
+    ///     The provider registers two fixes on the <c>NCDI002</c> diagnostic the source generator raises for a read only
+    ///     mutable collection property. The first adds a public setter so the reloaded collection can be assigned during a
+    ///     configuration hot reload; it is only offered when the reported member is a get-only auto-property (it has a
+    ///     getter accessor and no setter or init accessor). The second applies the <c>[SkipConfigProperty]</c> attribute so
+    ///     the property is excluded from the configuration graph and intentionally bound once at startup.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReadOnlyCollectionCodeFixProvider))]
+    [Shared]
+    public sealed class ReadOnlyCollectionCodeFixProvider : CodeFixProvider
+    {
+        private const string DiagnosticId = "NCDI002";
+
+        private const string AddSetterTitle = "Add a setter to support hot reload";
+
+        private const string SkipPropertyTitle = "Exclude the property from hot reload with [SkipConfigProperty]";
+
+        private const string SkipConfigPropertyAttributeName = "SkipConfigProperty";
+
+        private const string GeneratedNamespace = "Neovolve.Configuration.DependencyInjection.Generated";
+
+        /// <inheritdoc />
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(DiagnosticId);
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc />
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            if (root == null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+                var declaration = node.FirstAncestorOrSelf<PropertyDeclarationSyntax>();
+
+                if (declaration == null)
+                {
+                    continue;
+                }
+
+                if (CanAddSetter(declaration))
+                {
+                    var addSetter = CodeAction.Create(
+                        AddSetterTitle,
+                        cancellationToken => AddSetterAsync(context.Document, root, declaration, cancellationToken),
+                        equivalenceKey: AddSetterTitle);
+
+                    context.RegisterCodeFix(addSetter, diagnostic);
+                }
+
+                var skipProperty = CodeAction.Create(
+                    SkipPropertyTitle,
+                    cancellationToken => ApplySkipConfigPropertyAsync(context.Document, root, declaration,
+                        cancellationToken),
+                    equivalenceKey: SkipPropertyTitle);
+
+                context.RegisterCodeFix(skipProperty, diagnostic);
+            }
+        }
+
+        private static bool CanAddSetter(PropertyDeclarationSyntax declaration)
+        {
+            if (declaration.AccessorList == null)
+            {
+                // An expression bodied property has no accessor list, so a setter cannot be added by this fix.
+                return false;
+            }
+
+            var hasGetter = false;
+
+            foreach (var accessor in declaration.AccessorList.Accessors)
+            {
+                if (accessor.IsKind(SyntaxKind.SetAccessorDeclaration)
+                    || accessor.IsKind(SyntaxKind.InitAccessorDeclaration))
+                {
+                    // The property already has a setter or init accessor, so there is nothing to add.
+                    return false;
+                }
+
+                if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration))
+                {
+                    hasGetter = true;
+                }
+            }
+
+            return hasGetter;
+        }
+
+        private static Task<Document> AddSetterAsync(
+            Document document,
+            SyntaxNode root,
+            PropertyDeclarationSyntax declaration,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var setter = SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+
+            var accessors = declaration.AccessorList!.Accessors.Add(setter);
+            var accessorList = declaration.AccessorList.WithAccessors(accessors);
+            var replacement = declaration.WithAccessorList(accessorList);
+
+            var newRoot = root.ReplaceNode(declaration, replacement);
+
+            return Task.FromResult(document.WithSyntaxRoot(newRoot));
+        }
+
+        private static Task<Document> ApplySkipConfigPropertyAsync(
+            Document document,
+            SyntaxNode root,
+            PropertyDeclarationSyntax declaration,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var leadingTrivia = declaration.GetLeadingTrivia();
+            var indentation = leadingTrivia.LastOrDefault(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia));
+
+            var attribute = SyntaxFactory.Attribute(SyntaxFactory.IdentifierName(SkipConfigPropertyAttributeName));
+
+            // The attribute keeps the property's original leading trivia (blank lines and indentation) and sits on its
+            // own line, while the property is re-indented to the same column.
+            var attributeList = SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(attribute))
+                .WithLeadingTrivia(leadingTrivia)
+                .WithTrailingTrivia(SyntaxFactory.EndOfLine(Environment.NewLine), indentation);
+
+            var replacement = declaration
+                .WithLeadingTrivia(indentation)
+                .WithAttributeLists(declaration.AttributeLists.Insert(0, attributeList));
+
+            var newRoot = root.ReplaceNode(declaration, replacement);
+
+            if (newRoot is CompilationUnitSyntax compilationUnit)
+            {
+                newRoot = EnsureGeneratedNamespaceImported(compilationUnit);
+            }
+
+            return Task.FromResult(document.WithSyntaxRoot(newRoot));
+        }
+
+        private static CompilationUnitSyntax EnsureGeneratedNamespaceImported(CompilationUnitSyntax compilationUnit)
+        {
+            var alreadyImported = compilationUnit.Usings
+                .Any(directive => directive.Name?.ToString() == GeneratedNamespace);
+
+            if (alreadyImported)
+            {
+                return compilationUnit;
+            }
+
+            var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(GeneratedNamespace))
+                .WithTrailingTrivia(SyntaxFactory.EndOfLine(Environment.NewLine));
+
+            return compilationUnit.AddUsings(usingDirective);
+        }
+    }
+}
+

--- a/Neovolve.Configuration.DependencyInjection.Generator.UnitTests/ConfigureWithGeneratorTests.cs
+++ b/Neovolve.Configuration.DependencyInjection.Generator.UnitTests/ConfigureWithGeneratorTests.cs
@@ -464,6 +464,151 @@ namespace Sample
     }
 
     [Fact]
+    public void ReportsReadOnlyCollectionInsteadOfNotHotReloadable()
+    {
+        const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using Microsoft.Extensions.Hosting;
+
+    public sealed class RequiredDataConfig
+    {
+        public ICollection<string> RequiredData { get; } = new Collection<string>();
+    }
+
+    public sealed class RootConfig
+    {
+        public RequiredDataConfig Required { get; set; } = new();
+        public string RootValue { get; set; } = string.Empty;
+    }
+
+    public static class Caller
+    {
+        public static void Configure(IHostBuilder builder) => builder.ConfigureWith<RootConfig>();
+    }
+}";
+
+        var harness = GeneratorTestHarness.Run(source);
+
+        harness.GeneratorDiagnostics.Should()
+            .Contain(diagnostic => diagnostic.Id == "NCDI002"
+                && diagnostic.GetMessage().Contains("Sample.RequiredDataConfig.RequiredData"));
+
+        // The more specific NCDI002 replaces the generic NCDI001 for a type whose only members are read-only
+        // collections.
+        harness.GeneratorDiagnostics.Should()
+            .NotContain(diagnostic => diagnostic.Id == "NCDI001"
+                && diagnostic.GetMessage().Contains("Sample.RequiredDataConfig"));
+    }
+
+    [Fact]
+    public void ReportsReadOnlyCollectionOnTypeWithWritableProperties()
+    {
+        const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using Microsoft.Extensions.Hosting;
+
+    public sealed class ServerConfig
+    {
+        public string Name { get; set; } = string.Empty;
+        public ICollection<string> Tags { get; } = new Collection<string>();
+    }
+
+    public sealed class RootConfig
+    {
+        public ServerConfig Server { get; set; } = new();
+        public string RootValue { get; set; } = string.Empty;
+    }
+
+    public static class Caller
+    {
+        public static void Configure(IHostBuilder builder) => builder.ConfigureWith<RootConfig>();
+    }
+}";
+
+        var harness = GeneratorTestHarness.Run(source);
+
+        harness.GeneratorDiagnostics.Should()
+            .Contain(diagnostic => diagnostic.Id == "NCDI002"
+                && diagnostic.GetMessage().Contains("Sample.ServerConfig.Tags"));
+
+        harness.GeneratorDiagnostics.Should().NotContain(diagnostic => diagnostic.Id == "NCDI001");
+    }
+
+    [Fact]
+    public void DoesNotReportReadOnlyCollectionForWritableCollectionProperty()
+    {
+        const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Hosting;
+
+    public sealed class ServerConfig
+    {
+        public string Name { get; set; } = string.Empty;
+        public ICollection<string> Tags { get; set; } = new List<string>();
+    }
+
+    public sealed class RootConfig
+    {
+        public ServerConfig Server { get; set; } = new();
+        public string RootValue { get; set; } = string.Empty;
+    }
+
+    public static class Caller
+    {
+        public static void Configure(IHostBuilder builder) => builder.ConfigureWith<RootConfig>();
+    }
+}";
+
+        var harness = GeneratorTestHarness.Run(source);
+
+        harness.GeneratorDiagnostics.Should().NotContain(diagnostic => diagnostic.Id == "NCDI002");
+    }
+
+    [Fact]
+    public void ReportsNotHotReloadableForReadOnlyNonMutableCollection()
+    {
+        const string source = @"
+namespace Sample
+{
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Hosting;
+
+    public sealed class ReadOnlyListConfig
+    {
+        public IReadOnlyList<string> Items { get; } = new List<string>();
+    }
+
+    public sealed class RootConfig
+    {
+        public ReadOnlyListConfig ReadOnly { get; set; } = new();
+        public string RootValue { get; set; } = string.Empty;
+    }
+
+    public static class Caller
+    {
+        public static void Configure(IHostBuilder builder) => builder.ConfigureWith<RootConfig>();
+    }
+}";
+
+        var harness = GeneratorTestHarness.Run(source);
+
+        // An IReadOnlyList<T> has no Add, so the binder cannot populate it through a read-only property; it is a
+        // genuine NCDI001 case and is not a NCDI002 read-only mutable collection.
+        harness.GeneratorDiagnostics.Should().NotContain(diagnostic => diagnostic.Id == "NCDI002");
+        harness.GeneratorDiagnostics.Should()
+            .Contain(diagnostic => diagnostic.Id == "NCDI001"
+                && diagnostic.GetMessage().Contains("Sample.ReadOnlyListConfig"));
+    }
+
+    [Fact]
     public void ExcludesPropertyAndTypeMarkedToSkip()
     {
         const string source = @"

--- a/Neovolve.Configuration.DependencyInjection.Generator/AnalyzerReleases.Unshipped.md
+++ b/Neovolve.Configuration.DependencyInjection.Generator/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 NCDI001 | Neovolve.Configuration | Warning | Configuration type cannot be hot reloaded (value type or no writable properties); reports the root configuration type and the configuration path the type is bound at
+NCDI002 | Neovolve.Configuration | Warning | Read-only collection configuration property cannot be hot reloaded; recommends a settable property on the class and a get-only property on the interface

--- a/Neovolve.Configuration.DependencyInjection.Generator/ConfigGraphWalker.cs
+++ b/Neovolve.Configuration.DependencyInjection.Generator/ConfigGraphWalker.cs
@@ -98,8 +98,14 @@ internal static class ConfigGraphWalker
                 deepTypes.Add(deepType);
             }
 
+            // A read only property whose type is a mutable generic collection binds at startup (the binder adds items
+            // to the existing instance) but cannot be safely hot reloaded in place, so it is reported by NCDI002 with a
+            // recommendation to make the property settable on the class.
+            var isReadOnlyMutableCollection = canWrite == false
+                && IsMutableGenericCollection(property.Type, compilation);
+
             propertyModels.Add(new ConfigPropertyModel(property.Name, propertyTypeName, canWrite, isValueType,
-                changeKind, elementTypeName));
+                changeKind, elementTypeName, isReadOnlyMutableCollection, LocationInfo.CreateFrom(property)));
         }
 
         return new ConfigTypeModel(typeName, new EquatableArray<ConfigPropertyModel>(propertyModels.ToImmutable()),
@@ -224,6 +230,42 @@ internal static class ConfigGraphWalker
         }
 
         return null;
+    }
+
+    private static bool IsMutableGenericCollection(ITypeSymbol type, Compilation compilation)
+    {
+        // A type backed by ICollection<T> exposes Add/Clear so the configuration binder can populate it through a read
+        // only property at startup. IReadOnlyCollection<T>/IReadOnlyList<T> do not qualify because they cannot be added
+        // to, and a string is excluded even though it is enumerable.
+        if (type.SpecialType == SpecialType.System_String)
+        {
+            return false;
+        }
+
+        var collectionDefinition = compilation.GetTypeByMetadataName("System.Collections.Generic.ICollection`1");
+
+        if (collectionDefinition == null)
+        {
+            return false;
+        }
+
+        if (type is INamedTypeSymbol named
+            && named.IsGenericType
+            && SymbolEqualityComparer.Default.Equals(named.OriginalDefinition, collectionDefinition))
+        {
+            return true;
+        }
+
+        foreach (var implemented in type.AllInterfaces)
+        {
+            if (implemented.IsGenericType
+                && SymbolEqualityComparer.Default.Equals(implemented.OriginalDefinition, collectionDefinition))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ImplementsNonGenericICollection(ITypeSymbol type, Compilation compilation)

--- a/Neovolve.Configuration.DependencyInjection.Generator/ConfigPropertyModel.cs
+++ b/Neovolve.Configuration.DependencyInjection.Generator/ConfigPropertyModel.cs
@@ -7,7 +7,8 @@ namespace Neovolve.Configuration.DependencyInjection.Generator;
 internal readonly struct ConfigPropertyModel : IEquatable<ConfigPropertyModel>
 {
     public ConfigPropertyModel(string name, string typeFullyQualifiedName, bool canWrite, bool isValueType,
-        PropertyChangeKind changeKind, string? elementTypeFullyQualifiedName)
+        PropertyChangeKind changeKind, string? elementTypeFullyQualifiedName, bool isReadOnlyMutableCollection,
+        LocationInfo? declarationLocation)
     {
         Name = name;
         TypeFullyQualifiedName = typeFullyQualifiedName;
@@ -15,6 +16,8 @@ internal readonly struct ConfigPropertyModel : IEquatable<ConfigPropertyModel>
         IsValueType = isValueType;
         ChangeKind = changeKind;
         ElementTypeFullyQualifiedName = elementTypeFullyQualifiedName;
+        IsReadOnlyMutableCollection = isReadOnlyMutableCollection;
+        DeclarationLocation = declarationLocation;
     }
 
     public bool Equals(ConfigPropertyModel other)
@@ -24,7 +27,9 @@ internal readonly struct ConfigPropertyModel : IEquatable<ConfigPropertyModel>
             && CanWrite == other.CanWrite
             && IsValueType == other.IsValueType
             && ChangeKind == other.ChangeKind
-            && ElementTypeFullyQualifiedName == other.ElementTypeFullyQualifiedName;
+            && ElementTypeFullyQualifiedName == other.ElementTypeFullyQualifiedName
+            && IsReadOnlyMutableCollection == other.IsReadOnlyMutableCollection
+            && Nullable.Equals(DeclarationLocation, other.DeclarationLocation);
     }
 
     public override bool Equals(object? obj)
@@ -42,6 +47,8 @@ internal readonly struct ConfigPropertyModel : IEquatable<ConfigPropertyModel>
         hash = (hash * 31) + IsValueType.GetHashCode();
         hash = (hash * 31) + ChangeKind.GetHashCode();
         hash = (hash * 31) + (ElementTypeFullyQualifiedName?.GetHashCode() ?? 0);
+        hash = (hash * 31) + IsReadOnlyMutableCollection.GetHashCode();
+        hash = (hash * 31) + (DeclarationLocation?.GetHashCode() ?? 0);
 
         return hash;
     }
@@ -50,7 +57,11 @@ internal readonly struct ConfigPropertyModel : IEquatable<ConfigPropertyModel>
 
     public PropertyChangeKind ChangeKind { get; }
 
+    public LocationInfo? DeclarationLocation { get; }
+
     public string? ElementTypeFullyQualifiedName { get; }
+
+    public bool IsReadOnlyMutableCollection { get; }
 
     public bool IsValueType { get; }
 

--- a/Neovolve.Configuration.DependencyInjection.Generator/ConfigureWithGenerator.cs
+++ b/Neovolve.Configuration.DependencyInjection.Generator/ConfigureWithGenerator.cs
@@ -100,6 +100,7 @@ public sealed class ConfigureWithGenerator : IIncrementalGenerator
     private static void ReportNotHotReloadable(SourceProductionContext context, IEnumerable<RootModel> roots)
     {
         var reported = new HashSet<string>(StringComparer.Ordinal);
+        var reportedProperties = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var root in roots)
         {
@@ -120,6 +121,11 @@ public sealed class ConfigureWithGenerator : IIncrementalGenerator
                     continue;
                 }
 
+                var typeDisplayName = StripGlobal(configType.FullyQualifiedName);
+
+                var hasReadOnlyCollection = ReportReadOnlyCollections(context, configType, typeDisplayName, root,
+                    reportedProperties);
+
                 string reason;
                 string fix;
 
@@ -130,6 +136,14 @@ public sealed class ConfigureWithGenerator : IIncrementalGenerator
                 }
                 else if (configType.Properties.Count > 0 && configType.HasWritableProperty == false)
                 {
+                    if (hasReadOnlyCollection)
+                    {
+                        // The only members are read only collections, which NCDI002 reports with a specific,
+                        // actionable recommendation. Adding a setter there also satisfies NCDI001, so the generic
+                        // "no writable properties" warning would be redundant and is suppressed.
+                        continue;
+                    }
+
                     reason = "has no writable properties";
                     fix = "add settable properties or convert it to a mutable class";
                 }
@@ -147,17 +161,62 @@ public sealed class ConfigureWithGenerator : IIncrementalGenerator
                     ?? root.InvocationLocation?.ToLocation()
                     ?? Location.None;
 
-                var displayName = configType.FullyQualifiedName.StartsWith("global::", StringComparison.Ordinal)
-                    ? configType.FullyQualifiedName.Substring("global::".Length)
-                    : configType.FullyQualifiedName;
-
                 var pathDescription = DescribeConfigPaths(root, configType.FullyQualifiedName, pathsByType);
 
                 context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.NotHotReloadable, location, displayName, reason, fix, pathDescription));
+                    DiagnosticDescriptors.NotHotReloadable, location, typeDisplayName, reason, fix, pathDescription));
             }
         }
     }
+
+    private static bool ReportReadOnlyCollections(SourceProductionContext context, ConfigTypeModel configType,
+        string typeDisplayName, RootModel root, HashSet<string> reportedProperties)
+    {
+        if (configType.IsValueType)
+        {
+            // A value type is registered as a one-time snapshot and is never hot reloaded, so its read only collection
+            // properties are not relevant to hot reload.
+            return false;
+        }
+
+        var found = false;
+
+        foreach (var property in configType.Properties)
+        {
+            if (property.IsReadOnlyMutableCollection == false)
+            {
+                continue;
+            }
+
+            found = true;
+
+            var key = configType.FullyQualifiedName + "." + property.Name;
+
+            if (reportedProperties.Add(key) == false)
+            {
+                continue;
+            }
+
+            var location = property.DeclarationLocation?.ToLocation()
+                ?? configType.DeclarationLocation?.ToLocation()
+                ?? root.InvocationLocation?.ToLocation()
+                ?? Location.None;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ReadOnlyCollectionNotHotReloadable, location,
+                typeDisplayName + "." + property.Name));
+        }
+
+        return found;
+    }
+
+    private static string StripGlobal(string fullyQualifiedName)
+    {
+        return fullyQualifiedName.StartsWith("global::", StringComparison.Ordinal)
+            ? fullyQualifiedName.Substring("global::".Length)
+            : fullyQualifiedName;
+    }
+
 
     private static Dictionary<string, List<string>> BuildConfigPathLookup(RootModel root)
     {

--- a/Neovolve.Configuration.DependencyInjection.Generator/DiagnosticDescriptors.cs
+++ b/Neovolve.Configuration.DependencyInjection.Generator/DiagnosticDescriptors.cs
@@ -25,4 +25,21 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: HelpLink);
+
+    /// <summary>
+    ///     A configuration property is a read only mutable collection. It binds at startup but cannot be hot reloaded in
+    ///     place safely, so the author is advised to expose a settable property on the class and a read only property on
+    ///     any interface.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ReadOnlyCollectionNotHotReloadable = new(
+        "NCDI002",
+        "Read-only collection configuration property cannot be hot reloaded",
+        "Configuration property '{0}' is a read-only collection; the injected instance binds it at startup but will not "
+        + "receive hot reload updates for it. Declare the property with a public getter and setter on the class so the "
+        + "reloaded collection is assigned atomically, and keep a get-only declaration on any interface so callers "
+        + "cannot replace it.",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLink);
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The **Neovolve.Configuration.DependencyInjection** NuGet package provides `IHost
   - [Excluding properties and types](#excluding-properties-and-types)
 - [Recommendations](#recommendations)
   - [Use read-only interface definitions for configuration types](#use-read-only-interface-definitions-for-configuration-types)
+  - [Collection properties must be settable on the class to hot reload](#collection-properties-must-be-settable-on-the-class-to-hot-reload)
   - [Properties for child configuration types should be classes](#properties-for-child-configuration-types-should-be-classes)
   - [Avoid resolving the root config service](#avoid-resolving-the-root-config-service)
 
@@ -302,7 +303,7 @@ public class DiagnosticState
 [assembly: SkipConfigType(typeof(SomeThirdPartyType))]
 ```
 
-The generator also reports diagnostic **NCDI001** when a configuration type in the graph cannot be hot reloaded (see [Configuration types must be mutable classes to hot reload](#configuration-types-must-be-mutable-classes-to-hot-reload)). A code fix is included to convert a `struct` configuration type into a class.
+The generator also reports diagnostic **NCDI001** when a configuration type in the graph cannot be hot reloaded (see [Configuration types must be mutable classes to hot reload](#configuration-types-must-be-mutable-classes-to-hot-reload)). A code fix is included to convert a `struct` configuration type into a class. It reports diagnostic **NCDI002** for a get-only collection property that binds at startup but cannot be hot reloaded (see [Collection properties must be settable on the class to hot reload](#collection-properties-must-be-settable-on-the-class-to-hot-reload)), with code fixes that add the setter or apply `[SkipConfigProperty]`.
 
 # Recommendations
 
@@ -310,6 +311,54 @@ The generator also reports diagnostic **NCDI001** when a configuration type in t
 Configuration class definitions require that properties are mutable to allow the configuration binding system to set the values. There is a risk of an application class mutating the configuration data after it is injected into a class constructor. The way to prevent unintended mutation of configuration data at runtime is to define a read-only interface for the configuration class. This will allow the configuration system to set the values but the application code will not be able to change the values.
 
 The `ConfigureWith<T>` extension method supports this by registering any configuration interfaces found under the root configuration class.
+
+Declare the properties as settable on the class so the configuration binder can assign the values and hot reload can update them, and expose them as get-only on the interface so application code cannot mutate the configuration after it is injected:
+
+```csharp
+public interface IServerConfig
+{
+    // Get-only on the interface: application code cannot change the values.
+    string Name { get; }
+    int Port { get; }
+}
+
+public class ServerConfig : IServerConfig
+{
+    // Get/set on the class: the binder assigns the values and hot reload updates them.
+    public string Name { get; set; } = string.Empty;
+    public int Port { get; set; }
+}
+```
+
+Inject `IServerConfig` (rather than `ServerConfig`) into application classes so they get read-only access to the configuration while still receiving hot reload updates.
+
+## Collection properties must be settable on the class to hot reload
+A collection configuration property (for example `ICollection<T>`, `IList<T>`, `ISet<T>` or a concrete `List<T>`) is bound at application startup whether or not the property has a setter, because the configuration binder adds the items into the existing collection instance. This happens during startup before the instance is injected anywhere, so the in-place population is safe.
+
+Hot reload is different. The library hot reloads by assigning the reloaded value onto the injected singleton, which is a single atomic reference assignment, so a reader sees either the whole previous value or the whole new value. A get-only collection property cannot be assigned, so the only way to update it at runtime would be to clear and refill the existing collection in place. That is not safe: application code enumerating the collection on another thread during the reload would observe a torn result or throw, because the mutation is not atomic. For this reason a get-only collection property is bound once at startup and is not hot reloaded.
+
+This limitation applies only to the raw injected types (the configuration class and its interfaces). It does not affect `IOptionsSnapshot<T>` or `IOptionsMonitor<T>`, which always reflect the latest configuration because each access binds a fresh instance with the collection populated from the current configuration. If a configuration type has a get-only collection that must observe changes at runtime, either make the property settable on the class (see below) or consume the configuration through `IOptionsSnapshot<T>`/`IOptionsMonitor<T>` instead of the raw injected type.
+
+To make a collection hot reload, declare it as a settable property (`{ get; set; }`) on the class so the reloaded collection is assigned atomically, and expose it as a get-only property on any interface so application code still cannot replace it:
+
+```csharp
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+public interface IRequiredDataConfig
+{
+    // Get-only on the interface: callers cannot replace the collection.
+    ICollection<ConfiguredData> RequiredData { get; }
+}
+
+public class RequiredDataConfig : IRequiredDataConfig
+{
+    // Get/set on the class: hot reload assigns the reloaded collection atomically.
+    public ICollection<ConfiguredData> RequiredData { get; set; } = new Collection<ConfiguredData>();
+}
+```
+
+The source generator reports a get-only collection property as warning **NCDI002**. Two code fixes are offered: one adds the setter for you, and one applies `[SkipConfigProperty]` to the property. If startup-only binding is intentional and the collection does not need to hot reload, keep the get-only property and either suppress NCDI002 for it or exclude it with `[SkipConfigProperty]`.
 
 ## Properties for child configuration types should be classes
 Assuming that any configuration interfaces hide unnecessary child configuration types, all properties that represent child configuration types should be defined as their classes rather than interfaces on the parent configuration class. The `ConfigureWith<T>` extension method walks the type hierarchy from the root configuration type at compile time using a source generator, finding and recursing through all the properties.


### PR DESCRIPTION
Fixes #87

## Problem

A get-only collection property triggered a misleading NCDI001 "no writable properties" warning:

```csharp
public class RequiredDataConfig : IRequiredDataConfig
{
    public ICollection<ConfiguredData> RequiredData { get; } = new Collection<ConfiguredData>();
}
```

The type actually binds fine at startup (the binder adds items into the existing collection). The real issue is hot reload: the library reloads by an atomic reference assignment onto the injected singleton, which a get-only property can't receive. The only in-place alternative — clear and refill the live collection — is unsafe, because application code enumerating it on another thread during reload would tear or throw. (See the [analysis comment on #87](https://github.com/roryprimrose/Neovolve.Configuration.DependencyInjection/issues/87#issuecomment-4841730058).)

## Change

Rather than attempt unsafe in-place mutation, the generator now emits a specific, actionable diagnostic and guides users to a safe pattern.

- **New diagnostic NCDI002** — reported on a get-only mutable collection property (a property whose type implements `ICollection<T>`), located at the property. It recommends declaring the property `{ get; set; }` on the class (so reload assigns the new collection atomically) and `{ get; }` on the interface (so callers can't replace it). `IReadOnlyList<T>`/`IReadOnlyCollection<T>` correctly stay NCDI001 (no `Add`).
- NCDI002 fires whether or not the type has other writable properties; the generic NCDI001 is suppressed when a type's only blocker is read-only collections (the NCDI002 fix also resolves it), avoiding a double warning.
- **Two code fixes** on NCDI002: add a setter, or apply `[SkipConfigProperty]` (imports the `Generated` namespace when needed). The add-setter fix is only offered for get-only auto-properties; the skip fix is always offered.
- **No runtime opt-out flag.** NCDI002 is a compile-time judgment; a runtime flag couldn't be seen by the analyzer. The compile-time-consistent opt-out is `[SkipConfigProperty]`.

## Docs

- New README recommendation "Collection properties must be settable on the class to hot reload" with example code and the concurrency rationale, plus a clarification that the limitation only affects raw injected types — `IOptionsSnapshot<T>`/`IOptionsMonitor<T>` reflect the latest configuration regardless.
- Added an example to "Use read-only interface definitions for configuration types".
- Source-generator section references NCDI002; `AnalyzerReleases.Unshipped.md` registers it.

## Validation

- Full suite passes (959 tests), including 4 new generator tests and 7 code-fix tests.
- Solution builds clean.
